### PR TITLE
Remove unused imports from perps flow

### DIFF
--- a/jupiter_core/jupiter_perps_flow.py
+++ b/jupiter_core/jupiter_perps_flow.py
@@ -1,8 +1,6 @@
 import logging
 from playwright.sync_api import Error
 from data.models import Order  # Import the new Order model from models.py
-import uuid  # Only needed if you want to do additional ID handling
-from datetime import datetime
 from dotenv import load_dotenv
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- trim unused `uuid` and `datetime` imports from `jupiter_perps_flow`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'phantom_workflow' from 'auto_core')*

------
https://chatgpt.com/codex/tasks/task_e_683a45a873b4832180e70d1443d4d47a