### PR TITLE
Add step registry module

### DIFF
--- a/jupiter_core/auto_engine/__init__.py
+++ b/jupiter_core/auto_engine/__init__.py
@@ -1,0 +1,5 @@
+"""Components for the Jupiter Auto Engine."""
+
+from .step_registry import StepRegistry
+
+__all__ = ["StepRegistry"]

--- a/jupiter_core/auto_engine/step_registry.py
+++ b/jupiter_core/auto_engine/step_registry.py
@@ -1,0 +1,28 @@
+"""Simple registry for Jupiter Auto Engine steps."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+
+class StepRegistry:
+    """Registry mapping step names to callables."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, Callable] = {}
+
+    def register(self, name: str, func: Callable) -> None:
+        """Register a step function under ``name``."""
+        self._registry[name] = func
+
+    def get(self, name: str) -> Optional[Callable]:
+        """Return the registered step function for ``name``."""
+        return self._registry.get(name)
+
+    def all(self) -> Dict[str, Callable]:
+        """Return a copy of the registry mapping."""
+        return dict(self._registry)
+
+    def unregister(self, name: str) -> None:
+        """Remove a previously registered step."""
+        self._registry.pop(name, None)


### PR DESCRIPTION
## Summary
- create `auto_engine` module inside `jupiter_core`
- implement `StepRegistry` to map step names to callables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a51b91c3c8321925b232dca4df6d8