### PR TITLE
Add isolated margin automation step

### DIFF
--- a/jupiter_auto_engine.py
+++ b/jupiter_auto_engine.py
@@ -1,0 +1,46 @@
+from typing import Optional
+from jupiter_core.phantom_manager import PhantomManager
+from jupiter_core.jupiter_perps_flow import JupiterPerpsFlow
+
+
+class JupiterAutoEngine:
+    """Minimal automation engine for Jupiter perps demo."""
+
+    def __init__(self, extension_path: str, dapp_url: str, *, phantom_password: Optional[str] = None, headless: bool = False) -> None:
+        self.extension_path = extension_path
+        self.dapp_url = dapp_url
+        self.phantom_password = phantom_password
+        self.headless = headless
+
+        self.pm = PhantomManager(extension_path=self.extension_path, headless=self.headless)
+        self.pm.launch_browser()
+        self.jp = JupiterPerpsFlow(self.pm)
+
+    # ------------------------------------------------------------------
+    def step_connect_wallet(self) -> None:
+        self.pm.connect_wallet(dapp_url=self.dapp_url, phantom_password=self.phantom_password)
+
+    def step_unlock_wallet(self) -> None:
+        if self.phantom_password:
+            self.pm.unlock_phantom(self.phantom_password)
+
+    def step_set_position_type(self, position_type: str) -> None:
+        self.jp.select_position_type(position_type)
+
+    def step_set_payment_asset(self, asset: str) -> None:
+        self.jp.select_payment_asset(asset)
+
+    def step_set_leverage(self, leverage: str) -> None:
+        self.jp.set_leverage(leverage)
+
+    def step_set_position_size(self, size: str) -> None:
+        self.jp.set_position_size(size)
+
+    def step_switch_to_isolated_margin(self) -> None:
+        self.jp.switch_to_isolated_margin()
+
+    def step_approve_transaction(self) -> None:
+        self.pm.approve_transaction("text=Confirm")
+
+    def step_capture_order_payload(self, keyword: str):
+        return self.pm.capture_order_payload(keyword)

--- a/jupiter_core/jupiter_perps_flow.py
+++ b/jupiter_core/jupiter_perps_flow.py
@@ -108,6 +108,19 @@ class JupiterPerpsFlow:
             logger.error("❌ Error setting leverage: %s", e)
             raise
 
+    def switch_to_isolated_margin(self):
+        """Switch the margin mode from Cross to Isolated."""
+        logger.debug("Switching margin mode to Isolated")
+        try:
+            if self.page.is_visible("button:has-text('Cross')"):
+                self.page.click("button:has-text('Cross')", timeout=5000)
+            self.page.click("text=Isolated", timeout=5000)
+            logger.debug("✅ Isolated margin selected")
+            self.order_definition["margin_mode"] = "isolated"
+        except Error as e:
+            logger.error("❌ Error switching margin mode: %s", e)
+            raise
+
     def capture_order_payload(self, url_keyword: str, timeout: int = 10000):
         logger.debug("Waiting for network request with keyword: %s", url_keyword)
         try:

--- a/step_registry.py
+++ b/step_registry.py
@@ -1,0 +1,16 @@
+from typing import Callable, Dict
+from jupiter_auto_engine import JupiterAutoEngine
+
+
+def build_step_registry(engine: JupiterAutoEngine) -> Dict[str, Callable[[], None]]:
+    return {
+        "connect_wallet": engine.step_connect_wallet,
+        "unlock_wallet": engine.step_unlock_wallet,
+        "set_position_type": lambda: engine.step_set_position_type("long"),
+        "set_payment_asset": lambda: engine.step_set_payment_asset("USDC"),
+        "set_leverage": lambda: engine.step_set_leverage("7x"),
+        "set_position_size": lambda: engine.step_set_position_size("1.0"),
+        "switch_to_isolated_margin": engine.step_switch_to_isolated_margin,
+        "approve_transaction": engine.step_approve_transaction,
+        "capture_order_payload": lambda: engine.step_capture_order_payload("order-submit"),
+    }


### PR DESCRIPTION
## Summary
- implement `switch_to_isolated_margin` in `JupiterPerpsFlow`
- expose new step in `JupiterAutoEngine`
- map `switch_to_isolated_margin` step in `step_registry`

## Testing
- `python -m py_compile step_registry.py jupiter_auto_engine.py jupiter_core/jupiter_perps_flow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a51bcd0c883218aad9ed969aef9bc