### PR TITLE
Add modular engine under jupiter_core

### DIFF
--- a/jupiter_core/README.md
+++ b/jupiter_core/README.md
@@ -1,0 +1,22 @@
+# Jupiter Core Modular Engine
+
+This folder contains a minimal async automation framework used for the Jupiter
+playground.  Steps live in `jupiter_core/steps` and are loaded dynamically by
+`jupiter_core/jupiter_modular_console.py`.
+
+## Adding Steps
+
+1. Create a file in `jupiter_core/steps` named `auto_<name>.py`.
+2. Implement an `async def run(engine)` function that performs your actions using
+   `engine.pm` (the `PhantomManager`) or `engine.jp` (the `JupiterPerpsFlow`).
+3. When the console runs it will automatically pick up the new module.
+
+## Running the Console
+
+```bash
+python -m jupiter_core.jupiter_modular_console
+```
+
+Select a step number from the menu and it will be executed in the launched
+browser context.  The sample steps demonstrate wallet connection,
+unlocking and setting a position type.

--- a/jupiter_core/__init__.py
+++ b/jupiter_core/__init__.py
@@ -8,4 +8,9 @@ try:
 except Exception:
     PhantomManager = None
 
-__all__ = ["JupiterPerpsFlow", "PhantomManager"]
+try:
+    from .engine import JupiterEngineCore
+except Exception:
+    JupiterEngineCore = None
+
+__all__ = ["JupiterPerpsFlow", "PhantomManager", "JupiterEngineCore"]

--- a/jupiter_core/engine/__init__.py
+++ b/jupiter_core/engine/__init__.py
@@ -1,0 +1,1 @@
+from .jupiter_engine_core import JupiterEngineCore

--- a/jupiter_core/engine/jupiter_engine_core.py
+++ b/jupiter_core/engine/jupiter_engine_core.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from jupiter_core.phantom_manager import PhantomManager
+from jupiter_core.jupiter_perps_flow import JupiterPerpsFlow
+
+
+class JupiterEngineCore:
+    """Async wrapper around :class:`PhantomManager` and :class:`JupiterPerpsFlow`."""
+
+    def __init__(
+        self,
+        extension_path: str,
+        dapp_url: str,
+        *,
+        phantom_password: Optional[str] = None,
+        headless: bool = False,
+    ) -> None:
+        self.extension_path = extension_path
+        self.dapp_url = dapp_url
+        self.phantom_password = phantom_password
+        self.headless = headless
+
+        self.pm: Optional[PhantomManager] = None
+        self.jp: Optional[JupiterPerpsFlow] = None
+        self.page = None
+
+    # ------------------------------------------------------------------
+    async def launch(self) -> None:
+        """Launch the browser and initialise helpers."""
+        self.pm = PhantomManager(extension_path=self.extension_path, headless=self.headless)
+        await self.pm.launch_browser()
+        self.page = self.pm.page
+        self.jp = JupiterPerpsFlow(self.pm)
+
+    async def close(self) -> None:
+        if self.pm:
+            await self.pm.close()
+
+    # Context manager helpers -----------------------------------------
+    async def __aenter__(self) -> "JupiterEngineCore":
+        await self.launch()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()

--- a/jupiter_core/jupiter_modular_console.py
+++ b/jupiter_core/jupiter_modular_console.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import List
+
+from rich.console import Console
+from rich.prompt import Prompt
+
+from .engine.jupiter_engine_core import JupiterEngineCore
+
+console = Console()
+
+STEPS_PATH = Path(__file__).parent / "steps"
+EXTENSION_PATH = r"C:\\v0.83\\wallets\\phantom_wallet"
+DAPP_URL = "https://jup.ag/perps-legacy/short/SOL-SOL"
+PHANTOM_PASSWORD = None
+
+
+def load_steps() -> List[tuple[str, object]]:
+    steps = []
+    for file in sorted(STEPS_PATH.glob("auto_*.py")):
+        name = file.stem
+        spec = importlib.util.spec_from_file_location(name, file)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader
+        spec.loader.exec_module(module)
+        steps.append((name, module))
+    return steps
+
+
+async def main() -> None:
+    engine = JupiterEngineCore(
+        extension_path=EXTENSION_PATH,
+        dapp_url=DAPP_URL,
+        phantom_password=PHANTOM_PASSWORD,
+        headless=False,
+    )
+    await engine.launch()
+
+    steps = load_steps()
+    while True:
+        console.print("\n[bold magenta]Available Steps:[/bold magenta]")
+        for i, (name, _) in enumerate(steps, 1):
+            console.print(f"{i}) {name}")
+        choice = Prompt.ask("Select step number or 'q' to quit")
+        if choice.lower() in {"q", "quit", "exit"}:
+            break
+        if not choice.isdigit() or not (1 <= int(choice) <= len(steps)):
+            console.print("[red]Invalid selection[/red]")
+            continue
+        _, module = steps[int(choice) - 1]
+        await module.run(engine)
+
+    await engine.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/jupiter_core/steps/auto_connect_wallet.py
+++ b/jupiter_core/steps/auto_connect_wallet.py
@@ -1,0 +1,7 @@
+"""Connect Phantom wallet to the Jupiter dApp."""
+
+async def run(engine):
+    await engine.pm.connect_wallet(
+        dapp_url=engine.dapp_url,
+        phantom_password=engine.phantom_password,
+    )

--- a/jupiter_core/steps/auto_set_position_type.py
+++ b/jupiter_core/steps/auto_set_position_type.py
@@ -1,0 +1,4 @@
+"""Select a LONG position type via JupiterPerpsFlow."""
+
+async def run(engine):
+    engine.jp.select_position_type("long")

--- a/jupiter_core/steps/auto_unlock_wallet.py
+++ b/jupiter_core/steps/auto_unlock_wallet.py
@@ -1,0 +1,5 @@
+"""Unlock Phantom wallet using the engine's stored password."""
+
+async def run(engine):
+    if engine.phantom_password:
+        await engine.pm.unlock_phantom(engine.phantom_password)

--- a/tests/test_jupiter_core_modular_steps.py
+++ b/tests/test_jupiter_core_modular_steps.py
@@ -1,0 +1,80 @@
+import sys
+import types
+import importlib
+import pytest
+
+
+class DummyPM:
+    def __init__(self, *a, **k):
+        self.called = []
+        self.page = "page"
+
+    async def launch_browser(self):
+        self.called.append("launch_browser")
+
+    async def connect_wallet(self, **kwargs):
+        self.called.append(("connect_wallet", kwargs))
+
+    async def unlock_phantom(self, password):
+        self.called.append(("unlock_phantom", password))
+
+    async def close(self):
+        self.called.append("close")
+
+
+class DummyJP:
+    def __init__(self, *_):
+        self.called = []
+
+    def select_position_type(self, typ):
+        self.called.append(("select_position_type", typ))
+
+
+pm_mod = types.ModuleType("jupiter_core.phantom_manager")
+pm_mod.PhantomManager = DummyPM
+sys.modules.setdefault("jupiter_core.phantom_manager", pm_mod)
+
+jp_mod = types.ModuleType("jupiter_core.jupiter_perps_flow")
+jp_mod.JupiterPerpsFlow = DummyJP
+sys.modules.setdefault("jupiter_core.jupiter_perps_flow", jp_mod)
+
+# Stub out playwright modules that may be imported by other modules
+playwright_async = types.ModuleType("playwright.async_api")
+playwright_async.async_playwright = lambda: None
+playwright_async.Page = object
+playwright_async.BrowserContext = object
+playwright_async.Error = Exception
+sys.modules.setdefault("playwright.async_api", playwright_async)
+
+playwright_sync = types.ModuleType("playwright.sync_api")
+playwright_sync.Error = Exception
+sys.modules.setdefault("playwright.sync_api", playwright_sync)
+
+from jupiter_core.engine.jupiter_engine_core import JupiterEngineCore
+
+
+@pytest.mark.asyncio
+async def test_step_modules_execute():
+    engine = JupiterEngineCore("ext", "url", phantom_password="pw")
+    await engine.launch()
+
+    modules = [
+        importlib.import_module("jupiter_core.steps.auto_connect_wallet"),
+        importlib.import_module("jupiter_core.steps.auto_unlock_wallet"),
+        importlib.import_module("jupiter_core.steps.auto_set_position_type"),
+    ]
+
+    for mod in modules:
+        await mod.run(engine)
+
+    pm: DummyPM = engine.pm  # type: ignore
+    jp: DummyJP = engine.jp  # type: ignore
+
+    assert ("connect_wallet", {
+        "dapp_url": engine.dapp_url,
+        "phantom_password": engine.phantom_password,
+    }) in pm.called
+    assert ("unlock_phantom", engine.phantom_password) in pm.called
+    assert ("select_position_type", "long") in jp.called
+
+    await engine.close()


### PR DESCRIPTION
## Summary
- move modular engine into `jupiter_core`
- keep step modules and console under new package
- update README with new import paths
- adjust tests to import from `jupiter_core`

## Testing
- `pytest tests/test_jupiter_core_modular_steps.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a82f95c6883219f7052d120775e86