### PR TITLE
Ensure dotenv loading in auto console

### DIFF
--- a/jupiter_core/jupiter_auto_console.py
+++ b/jupiter_core/jupiter_auto_console.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
+from dotenv import load_dotenv
 from rich.console import Console
 from rich.prompt import Prompt
 
 from jupiter_core.engine.jupiter_engine_core import JupiterEngineCore
 from jupiter_core import jupiter_perps_steps as steps_module
+
+base_dir = Path(__file__).resolve().parent.parent
+load_dotenv(base_dir / ".env")
+load_dotenv(base_dir / ".env.example")
 
 console = Console()
 


### PR DESCRIPTION
## Summary
- load environment variables in `jupiter_auto_console`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jupiter_modular')*

------
https://chatgpt.com/codex/tasks/task_e_683b2b686db48321b86938e0f94dfe2a