### PR TITLE
Integrate Order Factory with OrderEngine

### DIFF
--- a/static/js/order_factory.js
+++ b/static/js/order_factory.js
@@ -1,0 +1,48 @@
+console.log('✅ order_factory.js loaded');
+
+document.addEventListener('DOMContentLoaded', () => {
+  function postJson(url, payload, label, icon = '✅') {
+    showToast(`${icon} ${label} started...`);
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data.message) {
+          showToast(`${icon} ${label} complete: ${data.message}`);
+        } else if (data.error) {
+          showToast(`❌ ${label} failed: ${data.error}`, true);
+        } else {
+          showToast(`⚠️ ${label} returned unknown response`, true);
+        }
+      })
+      .catch(err => {
+        console.error(`${label} error:`, err);
+        showToast(`❌ ${label} failed to connect`, true);
+      });
+  }
+
+  const launchBtn = document.getElementById('launchCoreBtn');
+  if (launchBtn) {
+    launchBtn.addEventListener('click', () => {
+      postJson('/sonic_labs/api/order_core_launch', {}, 'Launch Core', '🚀');
+    });
+  }
+
+  document.querySelectorAll('[data-engine-action]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const action = btn.getAttribute('data-engine-action');
+      const value = btn.getAttribute('data-value');
+      postJson('/sonic_labs/api/order_engine_action', { action, value }, action, '🔧');
+    });
+  });
+
+  const runFlowBtn = document.getElementById('runFullFlowBtn');
+  if (runFlowBtn) {
+    runFlowBtn.addEventListener('click', () => {
+      postJson('/sonic_labs/api/order_sequence', { flow: 'run_full_open_position_flow' }, 'Full Flow', '🧩');
+    });
+  }
+});

--- a/templates/order_factory.html
+++ b/templates/order_factory.html
@@ -29,8 +29,17 @@
 <div class="factory-container sonic-section-container sonic-section-middle">
   <div class="sonic-content-panel">
     <div class="section-title">Actions</div>
-    <div class="panel">[Atomic Actions]</div>
-    <div class="panel">[Full Order Flow]</div>
+    <div class="panel">
+      <button id="launchCoreBtn" class="btn btn-sm btn-secondary mb-2">Launch Core</button>
+      <div class="mb-2">
+        <button class="btn btn-sm btn-primary" data-engine-action="select_position_type" data-value="long">Long</button>
+        <button class="btn btn-sm btn-primary" data-engine-action="select_order_type" data-value="market">Market</button>
+        <button class="btn btn-sm btn-primary" data-engine-action="confirm_order">Confirm</button>
+      </div>
+    </div>
+    <div class="panel text-center">
+      <button id="runFullFlowBtn" class="btn btn-success">Run Full Demo Flow</button>
+    </div>
     <div class="panel">[Logs]</div>
   </div>
   <div class="sonic-content-panel">
@@ -46,4 +55,5 @@
 {{ super() }}
 <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
 <script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+<script src="{{ url_for('static', filename='js/order_factory.js') }}"></script>
 {% endblock %}

--- a/tests/test_order_factory_api.py
+++ b/tests/test_order_factory_api.py
@@ -1,0 +1,65 @@
+import importlib
+import types
+import pytest
+
+flask = importlib.import_module("flask")
+if not getattr(flask, "Flask", None):
+    pytest.skip("Flask not available", allow_module_level=True)
+from flask import Flask
+
+from sonic_labs.sonic_labs_bp import sonic_labs_bp
+
+
+class DummyEngine:
+    def __init__(self, log):
+        self.log = log
+
+    async def select_position_type(self, kind):
+        self.log.append(("select_position_type", kind))
+
+
+class DummySequencer:
+    def __init__(self, log):
+        self.log = log
+
+    async def run_full_open_position_flow(self, **kwargs):
+        self.log.append(("run_full_open_position_flow", kwargs))
+        return "ok"
+
+
+class DummyCore:
+    def __init__(self, log):
+        self.engine = DummyEngine(log)
+        self.sequencer = DummySequencer(log)
+
+
+def make_client(log):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.data_locker = object()
+    app.order_core = DummyCore(log)
+    app.register_blueprint(sonic_labs_bp, url_prefix="/sonic_labs")
+    return app.test_client()
+
+
+def test_engine_action_endpoint(monkeypatch):
+    log = []
+    client = make_client(log)
+    resp = client.post(
+        "/sonic_labs/api/order_engine_action",
+        json={"action": "select_position_type", "value": "long"},
+    )
+    assert resp.status_code == 200
+    assert ("select_position_type", "long") in log
+
+
+def test_sequence_endpoint(monkeypatch):
+    log = []
+    client = make_client(log)
+    resp = client.post(
+        "/sonic_labs/api/order_sequence",
+        json={"flow": "run_full_open_position_flow", "params": {"asset": "SOL"}},
+    )
+    assert resp.status_code == 200
+    assert any(evt[0] == "run_full_open_position_flow" for evt in log)
+


### PR DESCRIPTION
## Summary
- wire OrderCore into sonic labs blueprint
- expose API endpoints for launching and controlling OrderEngine
- enhance Order Factory UI with buttons that hit new endpoints
- add JS helper for Order Factory interactions
- test new API routes

## Testing
- `pytest tests/test_order_factory_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf5e59c188321984b3b3de00f03c7