### PR TITLE
Add trader factory page

### DIFF
--- a/templates/trader_factory.html
+++ b/templates/trader_factory.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block title %}Trader Factory{% endblock %}
+
+{% block extra_styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/trader_dashboard.css') }}">
+{% endblock %}
+
+{% block content %}
+{% set title_text = 'Trader Factory' %}
+{% include "title_bar.html" %}
+<div class="factory-container sonic-section-container sonic-section-middle">
+  <div class="sonic-content-panel">
+    <div class="section-title">Trader Info</div>
+    <div class="trader-card" id="trader-card">
+      <div class="trader-header">
+        <span class="avatar">{{ trader.avatar }}</span>
+        <h2>{{ trader.name }}</h2>
+        <span class="mood" id="mood">{{ trader.mood }}</span>
+      </div>
+      <div class="trader-body">
+        <p>Risk: {{ trader.risk_profile }}</p>
+        <p>Heat Index: <span id="heat">{{ trader.heat_index }}</span></p>
+        <p>Performance Score: <span id="score">{{ trader.performance_score }}</span></p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/trader_dashboard.js') }}"></script>
+{% endblock %}

--- a/tests/test_trader_bp.py
+++ b/tests/test_trader_bp.py
@@ -41,3 +41,9 @@ def test_trader_api(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["name"] == "Angie"
+
+
+def test_trader_factory_page(client):
+    resp = client.get("/trader/factory/Angie")
+    assert resp.status_code == 200
+    assert b"Angie" in resp.data

--- a/trader/trader_bp.py
+++ b/trader/trader_bp.py
@@ -25,6 +25,14 @@ def trader_page(name: str):
     return render_template("trader_dashboard.html", trader=trader)
 
 
+@trader_bp.route("/factory/<name>")
+def trader_factory(name: str):
+    """Render the trader factory page with loaded trader data."""
+    loader = _loader()
+    trader = loader.load_trader(name)
+    return render_template("trader_factory.html", trader=trader)
+
+
 @trader_bp.route("/api/<name>")
 def trader_api(name: str):
     loader = _loader()


### PR DESCRIPTION
## Summary
- create `trader_factory.html` template that extends `base.html` and uses `title_bar`
- add `/factory/<name>` route to serve trader data to the template
- test that the new page renders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683cf9844c6c8321afed70e2c9bb587c