### PR TITLE
Add full trader factory layout

### DIFF
--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -9,6 +9,7 @@
     <a class="btn nav-btn" href="/sonic_labs/hedge_report" title="Hedge Report"><span>🦔</span></a>
     <a class="btn nav-btn" href="/system/wallets" title="Wallet Manager"><span>💼</span></a>
     <a class="btn nav-btn" href="/sonic_labs/order_factory" title="Orders"><span>🛒</span></a>
+    <a class="btn nav-btn" href="{{ url_for('trader_bp.trader_factory_all') }}" title="Trader Factory"><span>🏭</span></a>
     <a class="btn nav-btn" href="{{ url_for('chat_gpt_bp.oracle_ui') }}" title="GPT Oracle"><span>🧙</span></a>
   </div>
   <div class="title-bar-center text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">

--- a/templates/trader_factory.html
+++ b/templates/trader_factory.html
@@ -1,0 +1,203 @@
+{% extends "base.html" %}
+{% block title %}Trader Factory{% endblock %}
+
+{% block extra_styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<style>
+  /* Core Layout */
+  body {
+    font-family: 'Segoe UI', sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #0a0a0a;
+    color: #f0f0f0;
+    display: flex;
+  }
+
+  .main {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  /* Panel Styles */
+  .panel {
+    margin: 10px;
+    padding: 10px;
+    background-color: #1b1b1b;
+    border-radius: 10px;
+    border: 1px solid #333;
+    height: calc(100% - 20px);
+    overflow-y: auto;
+  }
+
+  .cards-panel {
+    width: 60%;
+  }
+
+  .leaderboard-panel,
+  .activity-panel {
+    width: 20%;
+  }
+
+  /* Trader Card Grid */
+  .cards-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding: 10px;
+  }
+
+  .card {
+    width: 200px;
+    height: 300px;
+    perspective: 1000px;
+  }
+
+  .card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+    cursor: pointer;
+  }
+
+  .card:hover .card-inner {
+    transform: rotateY(180deg);
+  }
+
+  .card-front,
+  .card-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border: 1px solid #444;
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .card-front {
+    background-color: #1a1a1a;
+  }
+
+  .card-front img {
+    width: 100%;
+    height: 60%;
+    object-fit: cover;
+  }
+
+  .card-front h3 {
+    margin: 10px 0 5px;
+  }
+
+  .card-front p {
+    margin: 0;
+    font-size: 0.9em;
+    color: #aaa;
+  }
+
+  .card-back {
+    background-color: #222;
+    transform: rotateY(180deg);
+    padding: 10px;
+    font-size: 0.85em;
+    text-align: left;
+  }
+
+  /* Utility styles */
+  h2 {
+    margin-top: 0;
+    padding-left: 10px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  th, td {
+    padding: 8px;
+    text-align: left;
+    border-bottom: 1px solid #333;
+  }
+
+  th {
+    background-color: #1f1f1f;
+  }
+
+  ul {
+    list-style-type: none;
+    padding-left: 20px;
+  }
+
+  li {
+    margin-bottom: 10px;
+    font-size: 0.85em;
+    color: #ccc;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+{% set title_text = 'Trader Factory' %}
+{% include "title_bar.html" %}
+<div class="main">
+  <!-- Trader Cards Grid -->
+  <div class="panel cards-panel">
+    <h2>Traders</h2>
+    <div class="cards-container">
+      {% for trader in traders %}
+      <div class="card">
+        <div class="card-inner">
+          <div class="card-front">
+            <img src="{{ trader.avatar or 'https://placehold.co/200x180?text=' + trader.name }}" alt="{{ trader.name }}">
+            <h3>{{ trader.name }}</h3>
+            <p>{{ trader.persona }}</p>
+            <p>{{ trader.mood }}</p>
+          </div>
+          <div class="card-back">
+            <strong>Origin:</strong> {{ trader.origin_story }}<br>
+            <strong>Strategies:</strong><br>
+            {% for strat, weight in trader.strategies.items() %}
+            - {{ strat|replace('_', ' ')|title }} ({{ weight }})<br>
+            {% endfor %}<br>
+            <button>Ping Oracle</button>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  <!-- Leaderboard -->
+  <div class="panel leaderboard-panel">
+    <h2>Leaderboard</h2>
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Score</th><th>Mood</th></tr>
+      </thead>
+      <tbody>
+        {% for trader in traders %}
+        <tr><td>{{ trader.name }}</td><td>{{ trader.performance_score }}</td><td>{{ trader.mood }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Activity Log -->
+  <div class="panel activity-panel">
+    <h2>Activity Log</h2>
+    <ul>
+      <li>TraderVader buys 0.1 SOL – 3:45pm 5/3/23</li>
+      <li>Nina opens BTC hedge – 11:12am 5/3/23</li>
+      <li>Wizard adjusts leverage – 9:30am 5/3/23</li>
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_trader_bp.py
+++ b/tests/test_trader_bp.py
@@ -41,3 +41,15 @@ def test_trader_api(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["name"] == "Angie"
+
+
+def test_trader_factory_page(client):
+    resp = client.get("/trader/factory")
+    assert resp.status_code == 200
+    assert b"Angie" in resp.data
+
+
+def test_trader_factory_single(client):
+    resp = client.get("/trader/factory/Angie")
+    assert resp.status_code == 200
+    assert b"Angie" in resp.data

--- a/trader/trader_bp.py
+++ b/trader/trader_bp.py
@@ -25,6 +25,23 @@ def trader_page(name: str):
     return render_template("trader_dashboard.html", trader=trader)
 
 
+@trader_bp.route("/factory")
+def trader_factory_all():
+    """Show cards for all known traders."""
+    loader = _loader()
+    names = loader.persona_manager.list_personas()
+    traders = [loader.load_trader(n) for n in names]
+    return render_template("trader_factory.html", traders=traders)
+
+
+@trader_bp.route("/factory/<name>")
+def trader_factory_single(name: str):
+    """Render the trader factory page with a single trader."""
+    loader = _loader()
+    trader = loader.load_trader(name)
+    return render_template("trader_factory.html", traders=[trader])
+
+
 @trader_bp.route("/api/<name>")
 def trader_api(name: str):
     loader = _loader()


### PR DESCRIPTION
## Summary
- expand `trader_factory.html` with provided layout and dynamic trader info
- add navigation link from the title bar to trader factory
- list all traders from `PersonaManager` and allow single trader view
- update blueprint tests for new routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683cf9844c6c8321afed70e2c9bb587c