### PR TITLE
Add trader factory index and title icon

### DIFF
--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -9,6 +9,7 @@
     <a class="btn nav-btn" href="/sonic_labs/hedge_report" title="Hedge Report"><span>🦔</span></a>
     <a class="btn nav-btn" href="/system/wallets" title="Wallet Manager"><span>💼</span></a>
     <a class="btn nav-btn" href="/sonic_labs/order_factory" title="Orders"><span>🛒</span></a>
+    <a class="btn nav-btn" href="{{ url_for('trader_bp.trader_factory_index') }}" title="Trader Factory"><span>🏭</span></a>
     <a class="btn nav-btn" href="{{ url_for('chat_gpt_bp.oracle_ui') }}" title="GPT Oracle"><span>🧙</span></a>
   </div>
   <div class="title-bar-center text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">

--- a/templates/trader_factory.html
+++ b/templates/trader_factory.html
@@ -1,0 +1,222 @@
+{% extends "base.html" %}
+{% block title %}Trader Factory{% endblock %}
+{% block extra_styles %}
+{{ super() }}
+<style>
+    /* Core Layout */
+    body {
+      font-family: 'Segoe UI', sans-serif;
+      margin: 0;
+      padding: 0;
+      background-color: #0a0a0a;
+      color: #f0f0f0;
+      display: flex;
+    }
+
+    .main {
+      display: flex;
+      flex-direction: row;
+      width: 100%;
+      height: 100vh;
+      overflow: hidden;
+    }
+
+    /* Panel Styles */
+    .panel {
+      margin: 10px;
+      padding: 10px;
+      background-color: #1b1b1b;
+      border-radius: 10px;
+      border: 1px solid #333;
+      height: calc(100% - 20px);
+      overflow-y: auto;
+    }
+
+    .cards-panel {
+      width: 60%;
+    }
+
+    .leaderboard-panel,
+    .activity-panel {
+      width: 20%;
+    }
+
+    /* Trader Card Grid */
+    .cards-container {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+      padding: 10px;
+    }
+
+    .card {
+      width: 200px;
+      height: 300px;
+      perspective: 1000px;
+    }
+
+    .card-inner {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      text-align: center;
+      transition: transform 0.6s;
+      transform-style: preserve-3d;
+      cursor: pointer;
+    }
+
+    .card:hover .card-inner {
+      transform: rotateY(180deg);
+    }
+
+    .card-front,
+    .card-back {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      backface-visibility: hidden;
+      border: 1px solid #444;
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .card-front {
+      background-color: #1a1a1a;
+    }
+
+    .card-front img {
+      width: 100%;
+      height: 60%;
+      object-fit: cover;
+    }
+
+    .card-front h3 {
+      margin: 10px 0 5px;
+    }
+
+    .card-front p {
+      margin: 0;
+      font-size: 0.9em;
+      color: #aaa;
+    }
+
+    .card-back {
+      background-color: #222;
+      transform: rotateY(180deg);
+      padding: 10px;
+      font-size: 0.85em;
+      text-align: left;
+    }
+
+    /* Utility styles */
+    h2 {
+      margin-top: 0;
+      padding-left: 10px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      padding: 8px;
+      text-align: left;
+      border-bottom: 1px solid #333;
+    }
+
+    th {
+      background-color: #1f1f1f;
+    }
+
+    ul {
+      list-style-type: none;
+      padding-left: 20px;
+    }
+
+    li {
+      margin-bottom: 10px;
+      font-size: 0.85em;
+      color: #ccc;
+    }
+  </style>
+{% endblock %}
+{% block content %}
+{% set title_text = 'Trader Factory' %}
+{% include "title_bar.html" %}
+<div class="main">
+  {% if traders %}
+  <!-- Trader Cards Grid -->
+  <div class="panel cards-panel">
+    <h2>Traders</h2>
+    <div class="cards-container">
+      {% for t in traders %}
+      <div class="card">
+        <div class="card-inner">
+          <div class="card-front">
+            <img src="https://placehold.co/200x180/FF0000/FFF?text={{ t.name }}" alt="{{ t.name }}">
+            <h3>{{ t.name }}</h3>
+            <p>{{ t.persona }}</p>
+            <p>{{ t.mood }} Mood</p>
+          </div>
+          <div class="card-back">
+            <strong>Origin:</strong> {{ t.origin_story }}<br>
+            <strong>Strategies:</strong><br>
+            {% for s, w in t.strategies.items() %}- {{ s }} ({{ w }})<br>{% endfor %}
+            <br>
+            <button>Ping Oracle</button>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  <!-- Leaderboard -->
+  <div class="panel leaderboard-panel">
+    <h2>Leaderboard</h2>
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Score</th><th>Mood</th></tr>
+      </thead>
+      <tbody>
+        {% for t in leaders %}
+        <tr><td>{{ t.name }}</td><td>{{ t.performance_score }}</td><td>{{ t.mood }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <!-- Activity Log -->
+  <div class="panel activity-panel">
+    <h2>Activity Log</h2>
+    <ul>
+      {% for item in activity or [] %}
+      <li>{{ item }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% else %}
+  <!-- Single Trader Fallback -->
+  <div class="factory-container sonic-section-container sonic-section-middle">
+    <div class="sonic-content-panel">
+      <div class="section-title">Trader Info</div>
+      <div class="trader-card" id="trader-card">
+        <div class="trader-header">
+          <span class="avatar">{{ trader.avatar }}</span>
+          <h2>{{ trader.name }}</h2>
+          <span class="mood" id="mood">{{ trader.mood }}</span>
+        </div>
+        <div class="trader-body">
+          <p>Risk: {{ trader.risk_profile }}</p>
+          <p>Heat Index: <span id="heat">{{ trader.heat_index }}</span></p>
+          <p>Performance Score: <span id="score">{{ trader.performance_score }}</span></p>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/trader_dashboard.js') }}"></script>
+{% endblock %}

--- a/tests/test_trader_bp.py
+++ b/tests/test_trader_bp.py
@@ -41,3 +41,15 @@ def test_trader_api(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["name"] == "Angie"
+
+
+def test_trader_factory_page(client):
+    resp = client.get("/trader/factory/Angie")
+    assert resp.status_code == 200
+    assert b"Angie" in resp.data
+
+
+def test_trader_factory_index(client):
+    resp = client.get("/trader/factory")
+    assert resp.status_code == 200
+    assert b"Angie" in resp.data

--- a/trader/trader_bp.py
+++ b/trader/trader_bp.py
@@ -25,6 +25,27 @@ def trader_page(name: str):
     return render_template("trader_dashboard.html", trader=trader)
 
 
+@trader_bp.route("/factory")
+def trader_factory_index():
+    """Display all traders in the factory."""
+    loader = _loader()
+    names = loader.persona_manager.list_personas()
+    traders = [loader.load_trader(n) for n in names]
+    # sort by performance score for the leaderboard
+    leaders = sorted(traders, key=lambda t: t.performance_score, reverse=True)
+    return render_template(
+        "trader_factory.html", traders=traders, leaders=leaders
+    )
+
+
+@trader_bp.route("/factory/<name>")
+def trader_factory(name: str):
+    """Render the trader factory page with loaded trader data."""
+    loader = _loader()
+    trader = loader.load_trader(name)
+    return render_template("trader_factory.html", trader=trader)
+
+
 @trader_bp.route("/api/<name>")
 def trader_api(name: str):
     loader = _loader()


### PR DESCRIPTION
## Summary
- expand `trader_factory.html` with grid layout and leaderboard
- add new `/factory` route to display all traders
- link to Trader Factory from the title bar
- test factory index page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683cf9844c6c8321afed70e2c9bb587c