### PR TITLE
Fix layout for Trader Factory

### DIFF
--- a/templates/trader_factory.html
+++ b/templates/trader_factory.html
@@ -34,12 +34,12 @@
     }
 
     .cards-panel {
-      width: 60%;
+      flex: 3;
     }
 
     .leaderboard-panel,
     .activity-panel {
-      width: 20%;
+      flex: 1;
     }
 
     /* Trader Card Grid */


### PR DESCRIPTION
## Summary
- use flexbox to size Trader Factory panels so all sections appear

## Testing
- `pytest -q` *(fails: ImportError cannot import name 'jupiter_perps_steps')*

------
https://chatgpt.com/codex/tasks/task_e_683d9856435883218bf10d621ba054ac