### PR TITLE
Use ALERT_THRESHOLDS_PATH constant

### DIFF
--- a/utils/schema_validation_service.py
+++ b/utils/schema_validation_service.py
@@ -7,6 +7,7 @@ import json
 import jsonschema
 from jsonschema import validate
 from core.core_imports import log
+from core.constants import ALERT_THRESHOLDS_PATH
 
 class SchemaValidationService:
     """
@@ -14,7 +15,7 @@ class SchemaValidationService:
     Can be invoked in post-deployment or other test suites.
     """
 
-    ALERT_THRESHOLDS_FILE = "c:/v0.8/config/alert_thresholds.json"
+    ALERT_THRESHOLDS_FILE = str(ALERT_THRESHOLDS_PATH)
 
     ALERT_THRESHOLDS_SCHEMA = {
         "type": "object",


### PR DESCRIPTION
## Summary
- use `ALERT_THRESHOLDS_PATH` constant for `SchemaValidationService`
- adjust tests

## Testing
- `pytest tests/test_schema_validation_service.py -q`
- `pytest tests/test_operations_monitor.py tests/test_startup_service_alert_thresholds.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ddc63f39c8321b9b8b51a5a98a2e5