### PR TITLE
Fix module path in new_tree_protocol

### DIFF
--- a/scripts/new_tree_protocol.py
+++ b/scripts/new_tree_protocol.py
@@ -12,10 +12,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-from utils.startup_service import StartUpService
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from utils.startup_service import StartUpService
 
 
 def run(cmd: str) -> None:


### PR DESCRIPTION
## Summary
- ensure repo root is on `sys.path` before importing `StartUpService`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'jupiter_perps_steps')*

------
https://chatgpt.com/codex/tasks/task_e_683de6185d808321b8e6124f3ec43c05