### PR TITLE
Improve Windows docs and new_tree error

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ PYTHONPATH=.
 If you have an older copy with an absolute `PYTHONPATH`, update or remove that
 line before running `flask` commands.
 
+Windows users should set these variables using PowerShell syntax:
+
+```powershell
+$env:FLASK_APP = "sonic_app.py"
+$env:FLASK_ENV = "development"
+$env:FLASK_DEBUG = "1"
+$env:PYTHONPATH = "."
+```
+
 Or execute the full test suite using:
 
 ```bash

--- a/scripts/new_tree_protocol.py
+++ b/scripts/new_tree_protocol.py
@@ -33,7 +33,16 @@ def ensure_requirements() -> None:
     req = REPO_ROOT / "requirements.txt"
     if not req.exists():
         raise SystemExit("requirements.txt not found")
-    run(f"{sys.executable} -m pip install -r \"{req}\"")
+    cmd = f"{sys.executable} -m pip install -r \"{req}\""
+    print(f"🔧 Running: {cmd}")
+    result = subprocess.run(cmd, shell=True)
+    if result.returncode != 0:
+        print(
+            "❌ Failed to install dependencies. "
+            "Ensure you are using Python 3.10+ and try upgrading pip with"
+        )
+        print(f"   {sys.executable} -m pip install --upgrade pip")
+        raise SystemExit(result.returncode)
 
 
 def seed_database() -> None:


### PR DESCRIPTION
## Summary
- document how to set Flask env vars in PowerShell
- warn about Python version & pip in new_tree_protocol dependency install

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jupiter_modular')*

------
https://chatgpt.com/codex/tasks/task_e_683de908631883219de3af7e2da1f0c0