### PR TITLE
Add trader factory link

### DIFF
--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -9,7 +9,7 @@
     <a class="btn nav-btn" href="/sonic_labs/hedge_report" title="Hedge Report"><span>🦔</span></a>
     <a class="btn nav-btn" href="/system/wallets" title="Wallet Manager"><span>💼</span></a>
       <a class="btn nav-btn" href="/sonic_labs/order_factory" title="Orders"><span>🛒</span></a>
-      <a class="btn nav-btn" href="{{ url_for('trader_bp.trader_cards') }}" title="Traders"><span>👤</span></a>
+      <a class="btn nav-btn" href="{{ url_for('show_trader_factory') }}" title="Trader Factory"><i class="fa-solid fa-industry"></i></a>
       <a class="btn nav-btn" href="{{ url_for('chat_gpt_bp.oracle_ui') }}" title="GPT Oracle"><span>🧙</span></a>
     </div>
   <div class="title-bar-center text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">

--- a/templates/trader_factory.html
+++ b/templates/trader_factory.html
@@ -1,12 +1,19 @@
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Trader Factory - Sim Page</title>
-  <link rel="stylesheet" href="style.css">
-</head>
-<body>
+{% extends "base.html" %}
+{% block title %}Trader Factory{% endblock %}
+
+{% block extra_styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
+{% endblock %}
+
+{% block content %}
+{% set title_text = 'Trader Factory' %}
+{% include "title_bar.html" %}
+
   <div class="main">
     <div class="row">
       <div class="panel cards-panel">
@@ -91,6 +98,11 @@
       </div>
     </div>
   </div>
-  <script src="script.js"></script>
-</body>
-</html>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/trader_dashboard.js') }}"></script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- update navigation bar in `title_bar.html` to link to Trader Factory page
- use Font Awesome icon so the link is visible on all browsers

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'jupiter_perps_steps')*


------
https://chatgpt.com/codex/tasks/task_e_683de080914483218774a55f03990dcd