### PR TITLE
Add venv check to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ installs the required Python packages, seeds the database with default wallets
 and alert thresholds, copies `.env.example` to `.env` when necessary and finally
 runs `StartUpService.run_all()` to verify the configuration.
 
+Activate the project's virtual environment **before** running the script. If you
+haven't created `.venv` yet, follow the [Quick Start](#quick-start) instructions
+above.
+
 Run this command after checking out the repository to stand up a working tree:
 
 ```bash

--- a/scripts/new_tree_protocol.py
+++ b/scripts/new_tree_protocol.py
@@ -8,6 +8,7 @@ cloning the project on a new machine.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -18,6 +19,13 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from utils.startup_service import StartUpService
+
+
+def ensure_virtualenv() -> None:
+    """Exit if no virtual environment is active."""
+    active = os.environ.get("VIRTUAL_ENV") or sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    if not active:
+        raise SystemExit("❌ Activate a virtual environment before running this script")
 
 
 def run(cmd: str) -> None:
@@ -66,6 +74,7 @@ def ensure_env_file() -> None:
 
 def new_tree_protocol() -> None:
     """Run all setup steps for a new installation."""
+    ensure_virtualenv()
     ensure_requirements()
     seed_database()
     ensure_env_file()


### PR DESCRIPTION
## Summary
- prevent running scripts/new_tree_protocol.py outside a venv
- remind users in README to activate `.venv` before using the setup script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jupiter_modular')*

------
https://chatgpt.com/codex/tasks/task_e_683df0ed1b3483218c111ec1a8334ba6