### PR TITLE
Use run_cycle in monitor entrypoints

### DIFF
--- a/monitor/position_monitor.py
+++ b/monitor/position_monitor.py
@@ -34,6 +34,6 @@ class PositionMonitor(BaseMonitor):
 if __name__ == "__main__":
     log.banner("🚀 SELF-RUN: PositionMonitor")
     monitor = PositionMonitor()
-    result = monitor._do_work()
+    result = monitor.run_cycle()
     log.success("🧾 PositionMonitor Run Complete", source="SelfTest", payload=result)
     log.banner("✅ Position Sync Finished")

--- a/monitor/price_monitor.py
+++ b/monitor/price_monitor.py
@@ -38,6 +38,6 @@ if __name__ == "__main__":
     log.banner("🚀 SELF-RUN: PriceMonitor")
 
     monitor = PriceMonitor()
-    result = monitor._do_work()
+    result = monitor.run_cycle()
 
     log.success("🧾 PriceMonitor Run Complete", source="SelfTest", payload=result)


### PR DESCRIPTION
## Summary
- ensure the price and position monitors use `run_cycle()` when executed directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jupiter_core')*

------
https://chatgpt.com/codex/tasks/task_e_683e3b4d2dd883218211d755fb53c199