### PR TITLE
Enforce venv for new_tree setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,8 @@ installs the required Python packages, seeds the database with default wallets
 and alert thresholds, copies `.env.example` to `.env` when necessary and finally
 runs `StartUpService.run_all()` to verify the configuration.
 
-Activate the project's virtual environment **before** running the script. If you
-haven't created `.venv` yet, follow the [Quick Start](#quick-start) instructions
-above.
+Activate the project's virtual environment **before** running the script. To
+create and activate `.venv`, follow the [Quick Start](#quick-start) section.
 
 Run this command after checking out the repository to stand up a working tree:
 

--- a/scripts/new_tree_protocol.py
+++ b/scripts/new_tree_protocol.py
@@ -23,7 +23,7 @@ from utils.startup_service import StartUpService
 
 def ensure_virtualenv() -> None:
     """Exit if no virtual environment is active."""
-    active = os.environ.get("VIRTUAL_ENV") or sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    active = os.environ.get("VIRTUAL_ENV") or sys.prefix != sys.base_prefix
     if not active:
         raise SystemExit("❌ Activate a virtual environment before running this script")
 


### PR DESCRIPTION
## Summary
- require an active virtual environment in `new_tree_protocol.py`
- clarify README about activating `.venv` before running the script and link back to Quick Start

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3be977988321869a4b21c6b208e7