### PR TITLE
Fix short_datetime filter usage

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -26,6 +26,7 @@ from data.models import AlertThreshold
 from wallets.wallet_schema import WalletIn
 from positions.position_core import PositionCore
 from positions.hedge_manager import HedgeManager
+from utils.template_filters import short_datetime
 
 UPLOAD_FOLDER = os.path.join("static", "uploads", "wallets")
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
@@ -36,6 +37,9 @@ system_bp = Blueprint(
     url_prefix="/system",
     template_folder="../templates",
 )
+
+# Register template filters when the blueprint is attached to an app.
+system_bp.add_app_template_filter(short_datetime, "short_datetime")
 
 # Allow this blueprint to find templates in the project's main templates
 # directory when used within standalone test applications.

--- a/settings/settings_bp.py
+++ b/settings/settings_bp.py
@@ -6,6 +6,7 @@ from flask import Blueprint, render_template, jsonify, request, current_app
 from core.constants import THEME_CONFIG_PATH
 from core.logging import log
 from utils.route_decorators import route_log_alert
+from utils.template_filters import short_datetime
 
 settings_bp = Blueprint(
     'settings_bp',
@@ -13,6 +14,9 @@ settings_bp = Blueprint(
     url_prefix='/settings',
     template_folder='../templates/settings'  # ✅ Corrected
 )
+
+# Register template filters for standalone test apps.
+settings_bp.add_app_template_filter(short_datetime, 'short_datetime')
 
 @settings_bp.route("/theme")
 @route_log_alert

--- a/sonic_app.py
+++ b/sonic_app.py
@@ -86,27 +86,11 @@ app.config["SOLFLARE_PATH"] = os.getenv("SOLFLARE_PATH", "C:/alpha/wallets/solfl
 socketio = SocketIO(app)
 
 # --- Template Filters ---
+from utils.template_filters import short_datetime
 
-@app.template_filter("short_datetime")
-def short_datetime(value):
-    """Format timestamps like '2025-06-03T13:06:03.968905' as '3:06PM 6/3/25'."""
-    if not value:
-        return ""
-    try:
-        if isinstance(value, (int, float)):
-            dt = datetime.fromtimestamp(float(value))
-        else:
-            try:
-                dt = datetime.fromisoformat(str(value))
-            except ValueError:
-                dt = datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S")
-        formatted = dt.strftime("%I:%M%p %m/%d/%y")
-        if formatted.startswith("0"):
-            formatted = formatted[1:]
-        formatted = formatted.replace("/0", "/")
-        return formatted
-    except Exception:
-        return value
+# Register filters with the Flask app so they are available even when this file
+# is imported in isolation (e.g. during tests).
+app.add_template_filter(short_datetime, "short_datetime")
 
 # --- SINGLETON BACKEND ---
 app.data_locker = DataLocker(str(DB_PATH))

--- a/utils/template_filters.py
+++ b/utils/template_filters.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+
+def short_datetime(value):
+    """Format timestamps like '2025-06-03T13:06:03.968905' as '3:06PM 6/3/25'."""
+    if not value:
+        return ""
+    try:
+        if isinstance(value, (int, float)):
+            dt = datetime.fromtimestamp(float(value))
+        else:
+            try:
+                dt = datetime.fromisoformat(str(value))
+            except ValueError:
+                dt = datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S")
+        formatted = dt.strftime("%I:%M%p %m/%d/%y")
+        if formatted.startswith("0"):
+            formatted = formatted[1:]
+        formatted = formatted.replace("/0", "/")
+        return formatted
+    except Exception:
+        return value
+


### PR DESCRIPTION
## Summary
- create shared Jinja filters module
- register `short_datetime` filter for main app and blueprints
- use filter across standalone apps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trader')*

------
https://chatgpt.com/codex/tasks/task_e_683f853b66f483219c19ff843b94213d