### PR TITLE
Fix wallet manager table width

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -310,6 +310,7 @@ body.mobile-mode .sonic-section-container {
 
 .mini-table-box {
   border-radius: 0.75rem;
+  width: 100%;
 }
 
 .mini-table-box table {


### PR DESCRIPTION
## Summary
- ensure `.mini-table-box` spans the full panel width so tables fill the container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trader')*

------
https://chatgpt.com/codex/tasks/task_e_683fa45e68808321be3a56f31c1e7036