### PR TITLE
Implement delete return and integrate checks

### DIFF
--- a/data/dl_traders.py
+++ b/data/dl_traders.py
@@ -103,7 +103,13 @@ class DLTraderManager:
             log.route(f"Deleting trader: {name}", source="DLTraderManager")
             cursor = self.db.get_cursor()
             cursor.execute("DELETE FROM traders WHERE name = ?", (name,))
+            deleted = cursor.rowcount > 0
             self.db.commit()
-            log.info(f"🗑️ Trader deleted: {name}", source="DLTraderManager")
+            if deleted:
+                log.info(f"🗑️ Trader deleted: {name}", source="DLTraderManager")
+            else:
+                log.warning(f"Trader not found for deletion: {name}", source="DLTraderManager")
+            return deleted
         except Exception as e:
             log.error(f"❌ Failed to delete trader '{name}': {e}", source="DLTraderManager")
+            raise

--- a/tests/test_dl_trader_manager.py
+++ b/tests/test_dl_trader_manager.py
@@ -33,3 +33,9 @@ def test_crud_flow(dl):
     m.delete_trader("Alice")
     names = [t["name"] for t in m.list_traders()]
     assert "Alice" not in names and "Bob" in names
+
+
+def test_delete_nonexistent_trader_returns_false(dl):
+    m = dl.traders
+    result = m.delete_trader("Ghost")
+    assert result is False

--- a/tests/test_trader_bp.py
+++ b/tests/test_trader_bp.py
@@ -22,9 +22,17 @@ class DummyWallets:
         return self.get_wallets()
 
 
+class DummyTraders:
+    """Minimal traders manager stub."""
+
+    def delete_trader(self, name):
+        return False
+
+
 class DummyLocker:
     def __init__(self):
         self.wallets = DummyWallets()
+        self.traders = DummyTraders()
         self.positions = types.SimpleNamespace(get_all_positions=lambda: [])
         self.portfolio = types.SimpleNamespace(get_latest_snapshot=lambda: {})
 
@@ -71,3 +79,10 @@ def test_wallet_list_api(client):
     data = resp.get_json()
     assert data["success"] is True
     assert isinstance(data["wallets"], list)
+
+
+def test_delete_missing_trader_returns_error(client):
+    resp = client.delete("/trader/api/traders/Ghost/delete")
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert data["success"] is False

--- a/trader_core/trader_bp.py
+++ b/trader_core/trader_bp.py
@@ -106,7 +106,10 @@ def update_trader(name):
 def delete_trader(name):
     try:
         log.info(f"Deleting trader: {name}", source="API")
-        current_app.data_locker.traders.delete_trader(name)
+        deleted = current_app.data_locker.traders.delete_trader(name)
+        if not deleted:
+            log.warning(f"Trader not found for deletion: {name}", source="API")
+            return jsonify({"success": False, "error": "Trader not found"}), 404
         return jsonify({"success": True})
     except Exception as e:
         log.error(f"❌ Failed to delete trader: {e}", source="API")


### PR DESCRIPTION
## Summary
- return bool from `DLTraderManager.delete_trader`
- surface missing trader conditions from the API delete endpoint
- test DB manager returns `False` when trader missing
- integration test for delete endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fb5781ed88321a451f7caf169890a