### PR TITLE
Fix template literals in trader shop

### DIFF
--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -54,9 +54,9 @@ function loadAvatars() {
   select.addEventListener("change", () => {
     const val = select.value;
     if (val.startsWith("/static/")) {
-      preview.innerHTML = `<img src="\${val}" style="height: 60px; border-radius: 50%;">`;
+      preview.innerHTML = `<img src="${val}" style="height: 60px; border-radius: 50%;">`;
     } else {
-      preview.innerHTML = `<span style="font-size: 1.5rem;">\${val}</span>`;
+      preview.innerHTML = `<span style="font-size: 1.5rem;">${val}</span>`;
     }
   });
 }
@@ -103,9 +103,9 @@ function loadTraders() {
 
         let avatarHTML = "";
         if (trader.avatar?.startsWith("/static/")) {
-          avatarHTML = `<img src="\${trader.avatar}">`;
+          avatarHTML = `<img src="${trader.avatar}">`;
         } else if (trader.avatar) {
-          avatarHTML = `<div style="font-size: 1.5rem;">\${trader.avatar}</div>`;
+          avatarHTML = `<div style="font-size: 1.5rem;">${trader.avatar}</div>`;
         }
 
         card.innerHTML = `
@@ -187,7 +187,7 @@ document.getElementById("createTraderForm")?.addEventListener("submit", function
 function deleteTrader(name) {
   if (!confirm("Delete " + name + "?")) return;
 
-  fetch(`/trader/api/traders/\${encodeURIComponent(name)}/delete`, {
+  fetch(`/trader/api/traders/${encodeURIComponent(name)}/delete`, {
     method: 'DELETE'
   })
   .then(res => res.json())


### PR DESCRIPTION
## Summary
- allow interpolation in trader shop JS by dropping escape sequences

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fbb230de883218a9dc279df520a6c