### PR TITLE
Implement dynamic leaderboard

### DIFF
--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -83,15 +83,34 @@ function loadTraders() {
     .then(res => res.json())
     .then(data => {
       const container = document.getElementById('trader-cards');
+      const leaderboard = document.getElementById('leaderboard-body');
       if (!container) return;
       container.innerHTML = "";
+      if (leaderboard) leaderboard.innerHTML = "";
 
       if (!data.success || !Array.isArray(data.traders)) {
         container.innerHTML = "<p>No traders available.</p>";
         return;
       }
 
+
       let topScore = Math.max(...data.traders.map(t => t.performance_score ?? 0));
+
+      // sort traders by score descending for leaderboard
+      const sorted = [...data.traders].sort((a, b) => (b.performance_score ?? 0) - (a.performance_score ?? 0));
+
+      sorted.forEach(trader => {
+        if (leaderboard) {
+          const row = document.createElement('tr');
+          row.innerHTML = `
+            <td>${trader.name}</td>
+            <td>${trader.performance_score ?? '?'}</td>
+            <td>${trader.heat_index?.toFixed(1) ?? 'N/A'}</td>
+            <td>${trader.mood}</td>
+          `;
+          leaderboard.appendChild(row);
+        }
+      });
 
       data.traders.forEach(trader => {
         const card = document.createElement("div");

--- a/templates/trader_shop.html
+++ b/templates/trader_shop.html
@@ -84,13 +84,8 @@
               <th>Mood</th>
             </tr>
           </thead>
-          <tbody>
-            <tr>
-              <td>Trader A</td>
-              <td>78</td>
-              <td>23.7</td>
-              <td>Neutral</td>
-            </tr>
+          <tbody id="leaderboard-body">
+            <!-- Leaderboard rows will be inserted here -->
           </tbody>
         </table>
       </div>

--- a/trader_core/trader_core.py
+++ b/trader_core/trader_core.py
@@ -45,7 +45,7 @@ class TraderCore:
         totals = CalcServices().calculate_totals(positions)
         avg_heat = totals.get("avg_heat_index", 0.0)
         mood = evaluate_mood(avg_heat, getattr(persona, "moods", {}))
-        score = int(100 - abs(avg_heat - 30))
+        score = max(0, int(100 - avg_heat))
         trader = Trader(
             name=persona.name,
             avatar=getattr(persona, "avatar", ""),

--- a/trader_core/trader_loader.py
+++ b/trader_core/trader_loader.py
@@ -35,7 +35,7 @@ class TraderLoader:
         totals = CalcServices().calculate_totals(positions)
         avg_heat = totals.get("avg_heat_index", 0.0)
         mood = evaluate_mood(avg_heat, getattr(persona, "moods", {}))
-        score = int(100 - abs(avg_heat - 30))
+        score = max(0, int(100 - avg_heat))
         return Trader(
             name=persona.name,
             avatar=getattr(persona, "avatar", ""),


### PR DESCRIPTION
## Summary
- display leaderboard rows using live trader data
- compute `performance_score` from heat index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbd7d6df88321b1f40316a3fc30af