### PR TITLE
Add theme + layout toggles to trader shop

### DIFF
--- a/static/css/trader_shop.css
+++ b/static/css/trader_shop.css
@@ -44,11 +44,16 @@
   border: 2px solid gold;
 }
 
-/* Avatar image size enhanced */
-.card-front img {
-  height: 60px;
-  width: 60px;
+/* Avatar circle styling */
+.avatar-circle {
+  height: 80px;
+  width: 80px;
   border-radius: 50%;
   object-fit: cover;
-  margin: 0.5rem 0;
+  margin: 0.5rem auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent, #e0e0e0);
+  font-size: 2rem;
 }

--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -54,9 +54,9 @@ function loadAvatars() {
   select.addEventListener("change", () => {
     const val = select.value;
     if (val.startsWith("/static/")) {
-      preview.innerHTML = `<img src="${val}" style="height: 60px; border-radius: 50%;">`;
+      preview.innerHTML = `<img src="${val}" class="avatar-circle">`;
     } else {
-      preview.innerHTML = `<span style="font-size: 1.5rem;">${val}</span>`;
+      preview.innerHTML = `<div class="avatar-circle">${val}</div>`;
     }
   });
 }
@@ -122,9 +122,9 @@ function loadTraders() {
 
         let avatarHTML = "";
         if (trader.avatar?.startsWith("/static/")) {
-          avatarHTML = `<img src="${trader.avatar}">`;
+          avatarHTML = `<img src="${trader.avatar}" class="avatar-circle">`;
         } else if (trader.avatar) {
-          avatarHTML = `<div style="font-size: 1.5rem;">${trader.avatar}</div>`;
+          avatarHTML = `<div class="avatar-circle">${trader.avatar}</div>`;
         }
 
         card.innerHTML = `

--- a/templates/trader_shop.html
+++ b/templates/trader_shop.html
@@ -2,6 +2,11 @@
 {% block title %}Trader Shop{% endblock %}
 
 {% block extra_styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/trader_shop.css') }}">
 {% endblock %}
 
@@ -117,5 +122,8 @@
 {% endblock %}
 
 {% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
 <script src="{{ url_for('static', filename='js/trader_shop.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support theme and layout toggles on trader shop
- show avatar icons in larger circles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbf9a67ac8321a7270637d9d0ae59