### PR TITLE
Remove wallet panel status column

### DIFF
--- a/templates/wallets/wallet_manager.html
+++ b/templates/wallets/wallet_manager.html
@@ -50,7 +50,6 @@
           <th>🧠 Name</th>
           <th>📬 Address</th>
           <th>💰 Balance</th>
-          <th>✅ Active</th>
           <th>🛠️ Actions</th>
         </tr>
       </thead>
@@ -66,11 +65,10 @@
           </td>
           <td>{{ wallet.name }}</td>
           <td>
-            <span title="{{ wallet.public_address }}">{{ wallet.public_address[:9] }}</span>
+            <span title="{{ wallet.public_address }}">{{ wallet.public_address[:4] }}</span>
             <i class="fas fa-ellipsis-h ms-1" title="{{ wallet.public_address }}"></i>
           </td>
           <td>${{ '%.2f'|format(wallet.balance) }}</td>
-          <td>{{ "✔️" if wallet.is_active else "❌" }}</td>
           <td>
             <form action="{{ url_for('system.delete_wallet', name=wallet.name) }}" method="post" class="d-inline">
               <button type="submit" class="btn btn-sm btn-danger">🗑️</button>


### PR DESCRIPTION
## Summary
- simplify wallet manager table by removing Active status column
- truncate address display to first 4 characters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fbff6cea08321a743b4a7e1098b8d