### PR TITLE
Add YodaVault avatar

### DIFF
--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -56,6 +56,7 @@ WALLET_IMAGE_MAP = {
     "R2Vault": "r2vault.jpg",
     "LandoVault": "landovault.jpg",
     "VaderVault": "vadervault.jpg",
+    "YodaVault": "yodavault.jpg",
     "LandoVaultz": "landovault.jpg",
 }
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"

--- a/core/constants.py
+++ b/core/constants.py
@@ -54,6 +54,7 @@ R2VAULT_IMAGE = IMAGE_DIR / "r2vault.jpg"
 OBIVAULT_IMAGE = IMAGE_DIR / "obivault.jpg"
 LANDOVAULT_IMAGE = IMAGE_DIR / "landovault.jpg"
 VADERVAULT_IMAGE = IMAGE_DIR / "vadervault.jpg"
+YODAVAULT_IMAGE = IMAGE_DIR / "yodavault.jpg"
 
 # -----------------------------
 # 🧠 Blockchain & RPC

--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -25,6 +25,7 @@ WALLET_IMAGE_MAP = {
     "R2Vault": "r2vault.jpg",
     "LandoVault": "landovault.jpg",
     "VaderVault": "vadervault.jpg",
+    "YodaVault": "yodavault.jpg",
     "LandoVaultz": "landovault.jpg",
 }
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"

--- a/sonic_labs/jup_swap.py
+++ b/sonic_labs/jup_swap.py
@@ -24,6 +24,7 @@ WALLET_IMAGE_MAP = {
     "R2Vault": "r2vault.jpg",
     "LandoVault": "landovault.jpg",
     "VaderVault": "vadervault.jpg",
+    "YodaVault": "yodavault.jpg",
     "LandoVaultz": "landovault.jpg",
 }
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"

--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -24,6 +24,7 @@ WALLET_IMAGE_MAP = {
     "R2Vault": "r2vault.jpg",
     "LandoVault": "landovault.jpg",
     "VaderVault": "vadervault.jpg",
+    "YodaVault": "yodavault.jpg",
     "LandoVaultz": "landovault.jpg",
 }
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"

--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -28,6 +28,11 @@ const AVATARS = {
     icon: "/static/images/vadervault.jpg",
     moods: { calm: "🕳️", neutral: "🛡️", chaotic: "☠️" },
     heat: "💀"
+  },
+  "yodavault": {
+    icon: "/static/images/yodavault.jpg",
+    moods: { calm: "🌱", neutral: "🧘", chaotic: "⚔️" },
+    heat: "✨"
   }
 };
 

--- a/trader_core/persona_avatars.py
+++ b/trader_core/persona_avatars.py
@@ -55,6 +55,15 @@ AVATARS = {
         },
         "heat": "💀"
     },
+    "yodavault": {
+        "icon": "/static/images/yodavault.jpg",
+        "moods": {
+            "calm": "🌱",
+            "neutral": "🧘",
+            "chaotic": "⚔️"
+        },
+        "heat": "✨"
+    },
     "robot": {
         "icon": "🤖",
         "moods": {

--- a/ui_base_spec.md
+++ b/ui_base_spec.md
@@ -331,6 +331,7 @@ themes and page templates.
 | `unknown.png` | Placeholder icon for unknown assets. | `static/images/unknown.png` |
 | `unknown_wallet.jpg` | Generic wallet placeholder. | `static/images/unknown_wallet.jpg` |
 | `vadervault.jpg` | VaderVault wallet image. | `static/images/vadervault.jpg` |
+| `yodavault.jpg` | YodaVault wallet image. | `static/images/yodavault.jpg` |
 | `wallpaper2.jpg` | Additional wallpaper option. | `static/images/wallpaper2.jpg` |
 | `wallpaper2.png` | PNG variant of wallpaper2. | `static/images/wallpaper2.png` |
 | `wallpaper4.jpg` | Background image option. | `static/images/wallpaper4.jpg` |
@@ -340,6 +341,7 @@ themes and page templates.
 | `wally2.png` | Secondary Wally wallpaper used in funky theme. | `static/images/wally2.png` |
 | `landovault.jpg` (upload) | Sample uploaded wallet logo. | `static/uploads/wallets/landovault.jpg` |
 | `vadervault.jpg` (upload) | Sample uploaded wallet logo. | `static/uploads/wallets/vadervault.jpg` |
+| `yodavault.jpg` (upload) | Sample uploaded wallet logo. | `static/uploads/wallets/yodavault.jpg` |
 
 ### Sounds
 ```


### PR DESCRIPTION
## Summary
- add YodaVault to avatar registry and trader shop
- map `YodaVault` image across dashboards
- document new avatar
- include `yodavault.jpg` placeholder image
- **remove extra jpg from changelist**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840344ac16483218016b284b071f0b3