### PR TITLE
Handle missing personas in trader blueprint

### DIFF
--- a/tests/test_trader_bp.py
+++ b/tests/test_trader_bp.py
@@ -24,6 +24,17 @@ class DummyWallets:
 
 class DummyTraders:
     """Minimal traders manager stub."""
+    def __init__(self):
+        self._traders = []
+
+    def list_traders(self):
+        return list(self._traders)
+
+    def get_trader_by_name(self, name):
+        for t in self._traders:
+            if t.get("name") == name:
+                return t
+        return None
 
     def delete_trader(self, name):
         return False
@@ -41,6 +52,9 @@ class DummyLocker:
 
     def read_wallets(self):
         return self.wallets.get_wallets()
+
+    def get_wallet_by_name(self, name):
+        return self.wallets.get_wallet_by_name(name)
 
 
 @pytest.fixture
@@ -86,3 +100,12 @@ def test_delete_missing_trader_returns_error(client):
     assert resp.status_code == 404
     data = resp.get_json()
     assert data["success"] is False
+
+
+def test_list_traders_handles_missing_persona(client):
+    client.application.data_locker.traders._traders = [{"name": "Ghost"}]
+    resp = client.get("/trader/api/traders")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["traders"][0]["name"] == "Ghost"


### PR DESCRIPTION
## Summary
- gracefully handle missing persona files in `_enrich_trader`
- ensure wallet lookup only called if available
- extend dummy objects for API blueprint tests
- add regression test that listing traders works without a persona

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840509756c083218581a45633b76582