### PR TITLE
Add BobaVault avatar

### DIFF
--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -56,6 +56,8 @@ WALLET_IMAGE_MAP = {
     "R2Vault": "r2vault.jpg",
     "LandoVault": "landovault.jpg",
     "VaderVault": "vadervault.jpg",
+    "YodaVault": "yodavault.jpg",
+    "BobaVault": "bobavault.jpg",
     "LandoVaultz": "landovault.jpg",
 }
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"

--- a/core/constants.py
+++ b/core/constants.py
@@ -54,6 +54,8 @@ R2VAULT_IMAGE = IMAGE_DIR / "r2vault.jpg"
 OBIVAULT_IMAGE = IMAGE_DIR / "obivault.jpg"
 LANDOVAULT_IMAGE = IMAGE_DIR / "landovault.jpg"
 VADERVAULT_IMAGE = IMAGE_DIR / "vadervault.jpg"
+YODAVAULT_IMAGE = IMAGE_DIR / "yodavault.jpg"
+BOBAVAULT_IMAGE = IMAGE_DIR / "bobavault.jpg"
 
 # -----------------------------
 # 🧠 Blockchain & RPC

--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -25,6 +25,8 @@ WALLET_IMAGE_MAP = {
     "R2Vault": "r2vault.jpg",
     "LandoVault": "landovault.jpg",
     "VaderVault": "vadervault.jpg",
+    "YodaVault": "yodavault.jpg",
+    "BobaVault": "bobavault.jpg",
     "LandoVaultz": "landovault.jpg",
 }
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"

--- a/sonic_labs/jup_swap.py
+++ b/sonic_labs/jup_swap.py
@@ -24,6 +24,8 @@ WALLET_IMAGE_MAP = {
     "R2Vault": "r2vault.jpg",
     "LandoVault": "landovault.jpg",
     "VaderVault": "vadervault.jpg",
+    "YodaVault": "yodavault.jpg",
+    "BobaVault": "bobavault.jpg",
     "LandoVaultz": "landovault.jpg",
 }
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"

--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -24,6 +24,8 @@ WALLET_IMAGE_MAP = {
     "R2Vault": "r2vault.jpg",
     "LandoVault": "landovault.jpg",
     "VaderVault": "vadervault.jpg",
+    "YodaVault": "yodavault.jpg",
+    "BobaVault": "bobavault.jpg",
     "LandoVaultz": "landovault.jpg",
 }
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"

--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -28,6 +28,16 @@ const AVATARS = {
     icon: "/static/images/vadervault.jpg",
     moods: { calm: "🕳️", neutral: "🛡️", chaotic: "☠️" },
     heat: "💀"
+  },
+  "yodavault": {
+    icon: "/static/images/yodavault.jpg",
+    moods: { calm: "🌱", neutral: "🧘", chaotic: "⚔️" },
+    heat: "✨"
+  },
+  "bobavault": {
+    icon: "/static/images/bobavault.jpg",
+    moods: { calm: "🎯", neutral: "🤠", chaotic: "💣" },
+    heat: "🚀"
   }
 };
 

--- a/trader_core/persona_avatars.py
+++ b/trader_core/persona_avatars.py
@@ -55,6 +55,24 @@ AVATARS = {
         },
         "heat": "💀"
     },
+    "yodavault": {
+        "icon": "/static/images/yodavault.jpg",
+        "moods": {
+            "calm": "🌱",
+            "neutral": "🧘",
+            "chaotic": "⚔️"
+        },
+        "heat": "✨"
+    },
+    "bobavault": {
+        "icon": "/static/images/bobavault.jpg",
+        "moods": {
+            "calm": "🎯",
+            "neutral": "🤠",
+            "chaotic": "💣"
+        },
+        "heat": "🚀"
+    },
     "robot": {
         "icon": "🤖",
         "moods": {

--- a/ui_base_spec.md
+++ b/ui_base_spec.md
@@ -331,6 +331,8 @@ themes and page templates.
 | `unknown.png` | Placeholder icon for unknown assets. | `static/images/unknown.png` |
 | `unknown_wallet.jpg` | Generic wallet placeholder. | `static/images/unknown_wallet.jpg` |
 | `vadervault.jpg` | VaderVault wallet image. | `static/images/vadervault.jpg` |
+| `yodavault.jpg` | YodaVault wallet image. | `static/images/yodavault.jpg` |
+| `bobavault.jpg` | BobaVault wallet image. | `static/images/bobavault.jpg` |
 | `wallpaper2.jpg` | Additional wallpaper option. | `static/images/wallpaper2.jpg` |
 | `wallpaper2.png` | PNG variant of wallpaper2. | `static/images/wallpaper2.png` |
 | `wallpaper4.jpg` | Background image option. | `static/images/wallpaper4.jpg` |
@@ -340,6 +342,8 @@ themes and page templates.
 | `wally2.png` | Secondary Wally wallpaper used in funky theme. | `static/images/wally2.png` |
 | `landovault.jpg` (upload) | Sample uploaded wallet logo. | `static/uploads/wallets/landovault.jpg` |
 | `vadervault.jpg` (upload) | Sample uploaded wallet logo. | `static/uploads/wallets/vadervault.jpg` |
+| `yodavault.jpg` (upload) | Sample uploaded wallet logo. | `static/uploads/wallets/yodavault.jpg` |
+| `bobavault.jpg` (upload) | Sample uploaded wallet logo. | `static/uploads/wallets/bobavault.jpg` |
 
 ### Sounds
 ```


### PR DESCRIPTION
## Summary
- register BobaVault avatar asset and moods
- expose BobaVault in dashboard wallet mapping
- include BobaVault option in trader shop UI
- document new image in UI spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840344ac16483218016b284b071f0b3