### PR TITLE
Fix trader card balance display

### DIFF
--- a/trader_core/trader_bp.py
+++ b/trader_core/trader_bp.py
@@ -21,6 +21,7 @@ def _enrich_trader(trader: dict, dl, pm: PersonaManager, calc: CalcServices) -> 
         (persona.name + "Vault") if persona else f"{name}Vault"
     )
 
+    trader["wallet_balance"] = 0.0
     if wallet_name and hasattr(dl, "get_wallet_by_name"):
         w = dl.get_wallet_by_name(wallet_name)
         if w:


### PR DESCRIPTION
## Summary
- ensure each trader card uses a default 0 balance before lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b095684c8321a44c2956e8c66546