### PR TITLE
Add wallet balance to leaderboard

### DIFF
--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -116,6 +116,7 @@ function loadTraders() {
           row.innerHTML = `
             <td>${trader.name}</td>
             <td>${trader.performance_score ?? '?'}</td>
+            <td>$${trader.wallet_balance?.toFixed(2) ?? '0.00'}</td>
             <td>${trader.heat_index?.toFixed(1) ?? 'N/A'}</td>
             <td>${trader.mood}</td>
           `;

--- a/templates/trader_shop.html
+++ b/templates/trader_shop.html
@@ -83,6 +83,7 @@
             <tr>
               <th>Name</th>
               <th>Score</th>
+              <th>Balance</th>
               <th>Heat Index</th>
               <th>Mood</th>
             </tr>

--- a/tests/test_trader_bp.py
+++ b/tests/test_trader_bp.py
@@ -109,3 +109,4 @@ def test_list_traders_handles_missing_persona(client):
     data = resp.get_json()
     assert data["success"] is True
     assert data["traders"][0]["name"] == "Ghost"
+    assert "wallet_balance" in data["traders"][0]


### PR DESCRIPTION
## Summary
- display wallet balance in leaderboard table
- update JS to include balance column
- check wallet balance appears in trader API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b9896c0c8321b63e12e755c3889f