### PR TITLE
Add trader personas

### DIFF
--- a/tests/test_persona_loading.py
+++ b/tests/test_persona_loading.py
@@ -25,3 +25,10 @@ def test_persona_attributes_loaded():
     assert persona.strategy_weights == {"safe": 0.7, "cautious": 0.3}
     assert persona.instructions == "Adopt a conservative trading approach."
     assert hasattr(persona, "system_message")
+
+
+def test_trader_personas_load():
+    pm_mod = importlib.import_module("oracle_core.persona_manager")
+    manager = pm_mod.PersonaManager(base_dir="trader_core/personas")
+    for name in ("Vader", "R2", "Yoda", "Lando", "Leia"):
+        assert name in manager.list_personas()

--- a/trader_core/personas/Lando.json
+++ b/trader_core/personas/Lando.json
@@ -1,0 +1,13 @@
+{
+  "name": "Lando",
+  "profile": "Opportunistic",
+  "avatar": "landovault",
+  "strategy_weights": {
+    "dynamic_hedging": 0.6,
+    "profit_management": 0.4
+  },
+  "moods": {
+    "high_heat": "charming"
+  },
+  "description": "Smuggler turned trader looking for the next big score."
+}

--- a/trader_core/personas/Leia.json
+++ b/trader_core/personas/Leia.json
@@ -1,0 +1,13 @@
+{
+  "name": "Leia",
+  "profile": "Strategic",
+  "avatar": "leiavault",
+  "strategy_weights": {
+    "dynamic_hedging": 0.4,
+    "profit_management": 0.6
+  },
+  "moods": {
+    "high_heat": "resolute"
+  },
+  "description": "Fearless leader balancing caution with decisive action."
+}

--- a/trader_core/personas/R2.json
+++ b/trader_core/personas/R2.json
@@ -1,0 +1,13 @@
+{
+  "name": "R2",
+  "profile": "Robotic",
+  "avatar": "r2vault",
+  "strategy_weights": {
+    "dynamic_hedging": 0.5,
+    "profit_management": 0.5
+  },
+  "moods": {
+    "high_heat": "beeping"
+  },
+  "description": "Reliable droid executing trades with mechanical precision."
+}

--- a/trader_core/personas/Vader.json
+++ b/trader_core/personas/Vader.json
@@ -1,0 +1,13 @@
+{
+  "name": "Vader",
+  "profile": "Aggressive",
+  "avatar": "vadervault",
+  "strategy_weights": {
+    "dynamic_hedging": 0.8,
+    "profit_management": 0.2
+  },
+  "moods": {
+    "high_heat": "ruthless"
+  },
+  "description": "Dark side trader using fear to dominate the market."
+}

--- a/trader_core/personas/Yoda.json
+++ b/trader_core/personas/Yoda.json
@@ -1,0 +1,13 @@
+{
+  "name": "Yoda",
+  "profile": "Wise",
+  "avatar": "yodavault",
+  "strategy_weights": {
+    "dynamic_hedging": 0.3,
+    "profit_management": 0.7
+  },
+  "moods": {
+    "high_heat": "calm"
+  },
+  "description": "Old master guiding portfolios with patience and insight."
+}


### PR DESCRIPTION
## Summary
- add Star Wars personas for Trader Core
- test PersonaManager loading on new directory

## Testing
- `pytest tests/test_persona_loading.py::test_trader_personas_load -q`
- `pytest tests/test_persona_loading.py -q`
- `pytest tests/test_trader_core_crud.py -q`
- `pytest tests/test_trader_wallet_heat.py::test_trader_heat_and_refresh -q`


------
https://chatgpt.com/codex/tasks/task_e_6840d39508a48321a098bca790d32668