### PR TITLE
Add wallet balance refresh

### DIFF
--- a/tests/test_trader_bp.py
+++ b/tests/test_trader_bp.py
@@ -110,3 +110,18 @@ def test_list_traders_handles_missing_persona(client):
     assert data["success"] is True
     assert data["traders"][0]["name"] == "Ghost"
     assert "wallet_balance" in data["traders"][0]
+
+
+def test_list_traders_triggers_wallet_refresh(client):
+    called = {}
+
+    def refresh():
+        called["r"] = True
+
+    client.application.system_core = types.SimpleNamespace(
+        wallet_core=types.SimpleNamespace(refresh_wallet_balances=refresh)
+    )
+    resp = client.get("/trader/api/traders")
+    assert resp.status_code == 200
+    assert called.get("r") is True
+

--- a/trader_core/trader_bp.py
+++ b/trader_core/trader_bp.py
@@ -7,6 +7,7 @@ from utils.console_logger import ConsoleLogger as log
 from trader_core.mood_engine import evaluate_mood
 from calc_core.calc_services import CalcServices
 from oracle_core.persona_manager import PersonaManager
+from wallets.wallet_core import WalletCore
 
 
 def _enrich_trader(trader: dict, dl, pm: PersonaManager, calc: CalcServices) -> dict:
@@ -52,6 +53,12 @@ def trader_shop():
 def trader_wallets():
     """Return wallets for dropdown selections."""
     try:
+        wc = getattr(getattr(current_app, "system_core", None), "wallet_core", None) or WalletCore()
+        try:
+            wc.refresh_wallet_balances()
+        except Exception as exc:
+            log.debug(f"Wallet refresh failed: {exc}", source="TraderBP")
+
         wallets = current_app.data_locker.read_wallets()
         simple = [
             {"name": w.get("name"), "balance": w.get("balance", 0.0)} for w in wallets
@@ -120,6 +127,12 @@ def get_trader(name):
 def list_traders():
     try:
         log.info("Listing all traders", source="API")
+        wc = getattr(getattr(current_app, "system_core", None), "wallet_core", None) or WalletCore()
+        try:
+            wc.refresh_wallet_balances()
+        except Exception as exc:
+            log.debug(f"Wallet refresh failed: {exc}", source="TraderBP")
+
         traders = current_app.data_locker.traders.list_traders()
         pm = PersonaManager()
         calc = CalcServices()


### PR DESCRIPTION
## Summary
- add `refresh_wallet_balances` to WalletCore for updating balances in DB
- invoke refresh from trader blueprint before listing wallets or traders
- test refresh logic and ensure trader API triggers refresh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cdb2c81083218e0ce1ff78c8e08c