### PR TITLE
Update DataLocker schema migration

### DIFF
--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -281,6 +281,13 @@ class DataLocker:
         # --- Automatic schema migrations ---
         log.debug("Applying schema migrations", source="DataLocker")
         _ensure_column(cursor, "positions", "status TEXT DEFAULT 'ACTIVE'")
+        _ensure_column(cursor, "positions", "value REAL")
+        _ensure_column(cursor, "positions", "collateral REAL")
+        _ensure_column(cursor, "positions", "size REAL")
+        _ensure_column(cursor, "positions", "leverage REAL")
+        _ensure_column(cursor, "positions", "current_price REAL")
+        _ensure_column(cursor, "positions", "pnl_after_fees_usd REAL")
+        _ensure_column(cursor, "positions", "liquidation_distance REAL")
 
         # Ensure a default row exists for system vars so lookups don't fail
         log.debug("Ensuring system_vars default row", source="DataLocker")

--- a/data/dl_positions.py
+++ b/data/dl_positions.py
@@ -206,14 +206,24 @@ class DLPositionManager:
         CREATE TABLE IF NOT EXISTS positions (
             id TEXT PRIMARY KEY,
             asset_type TEXT,
+            position_type TEXT,
             entry_price REAL,
             liquidation_price REAL,
-            position_type TEXT,
+            travel_percent REAL,
+            value REAL,
+            collateral REAL,
+            size REAL,
+            leverage REAL,
             wallet_name TEXT,
+            last_updated TEXT,
+            alert_reference_id TEXT,
+            hedge_buddy_id TEXT,
+            current_price REAL,
+            liquidation_distance REAL,
+            heat_index REAL,
             current_heat_index REAL,
             pnl_after_fees_usd REAL,
-            travel_percent REAL,
-            liquidation_distance REAL
+            status TEXT DEFAULT 'ACTIVE'
         )""")
         cursor.execute("""
         CREATE TABLE IF NOT EXISTS alerts (
@@ -221,7 +231,6 @@ class DLPositionManager:
             created_at TEXT,
             alert_type TEXT,
             alert_class TEXT,
-            asset TEXT,
             asset_type TEXT,
             trigger_value REAL,
             condition TEXT,

--- a/data/verify_alert_db_schema.py
+++ b/data/verify_alert_db_schema.py
@@ -5,15 +5,24 @@ REQUIRED_TABLES = {
     CREATE TABLE IF NOT EXISTS positions (
         id TEXT PRIMARY KEY,
         asset_type TEXT,
+        position_type TEXT,
         entry_price REAL,
         liquidation_price REAL,
-        position_type TEXT,
+        travel_percent REAL,
+        value REAL,
+        collateral REAL,
+        size REAL,
+        leverage REAL,
         wallet_name TEXT,
+        last_updated TEXT,
+        alert_reference_id TEXT,
+        hedge_buddy_id TEXT,
+        current_price REAL,
+        liquidation_distance REAL,
+        heat_index REAL,
         current_heat_index REAL,
         pnl_after_fees_usd REAL,
-        travel_percent REAL,
-        liquidation_distance REAL
-        ,status TEXT DEFAULT 'ACTIVE'
+        status TEXT DEFAULT 'ACTIVE'
     )
     """,
     "alerts": """
@@ -22,7 +31,6 @@ REQUIRED_TABLES = {
         created_at TEXT,
         alert_type TEXT,
         alert_class TEXT,
-        asset TEXT,
         asset_type TEXT,
         trigger_value REAL,
         condition TEXT,


### PR DESCRIPTION
## Summary
- automatically ensure position value/collateral/size/leverage/current price/PnL/liquidation distance columns
- align CREATE TABLE statements in helper modules with DataLocker
- test that initialization upgrades old databases and wallet balance uses new column

## Testing
- `pytest -k wallet_core_balance -q`
- `pytest -k test_initialize_database_adds_value_column -q`


------
https://chatgpt.com/codex/tasks/task_e_6840ebe3a628832197edfc95cbccc90a