### PR TITLE
Add chrome_profile field to wallet schemas

### DIFF
--- a/wallets/wallet_repository.py
+++ b/wallets/wallet_repository.py
@@ -24,12 +24,18 @@ class WalletRepository:
     # 🧾 Get all wallets from DB
     def get_all_wallets(self) -> List[Wallet]:
         rows = self.dl.read_wallets()
-        return [Wallet(**row) for row in rows]
+        return [
+            Wallet(**{**row, "chrome_profile": row.get("chrome_profile", "Default")})
+            for row in rows
+        ]
 
     # 🔍 Get a wallet by its unique name
     def get_wallet_by_name(self, name: str) -> Optional[Wallet]:
         row = self.dl.get_wallet_by_name(name)
-        return Wallet(**row) if row else None
+        if row:
+            data = {**row, "chrome_profile": row.get("chrome_profile", "Default")}
+            return Wallet(**data)
+        return None
 
     # ➕ Insert new wallet into DB
     def add_wallet(self, wallet: WalletIn) -> None:
@@ -55,7 +61,14 @@ class WalletRepository:
     def export_to_json(self, path: str = WALLETS_JSON_PATH) -> None:
         wallets = self.get_all_wallets()
         with open(path, "w") as f:
-            json.dump([wallet.__dict__ for wallet in wallets], f, indent=2)
+            json.dump(
+                [
+                    {**w.__dict__, "chrome_profile": w.chrome_profile or "Default"}
+                    for w in wallets
+                ],
+                f,
+                indent=2,
+            )
 
     # ♻️ Restore from wallets.json
     def load_from_json(self, path: str = WALLETS_JSON_PATH) -> List[Wallet]:
@@ -63,4 +76,7 @@ class WalletRepository:
             return []
         with open(path, "r") as f:
             data = json.load(f)
-        return [Wallet(**item) for item in data]
+        return [
+            Wallet(**{**item, "chrome_profile": item.get("chrome_profile", "Default")})
+            for item in data
+        ]

--- a/wallets/wallet_schema.py
+++ b/wallets/wallet_schema.py
@@ -36,6 +36,7 @@ class WalletIn(BaseModel):
     name: str = Field(..., example="VaderVault", description="Unique wallet name")
     public_address: str = Field(..., example="0xABC123...", description="Public wallet address")
     private_address: Optional[str] = Field(None, description="Optional private key (only for dev)")
+    chrome_profile: Optional[str] = Field("Default", description="Chrome profile for Jupiter links")
     image_path: Optional[str] = Field(None, example="/static/img/vader.png")
     balance: float = Field(0.0, ge=0.0)
     tags: List[str] = Field(default_factory=list)
@@ -48,6 +49,7 @@ class WalletOut(BaseModel):
     public_address: str
     balance: float
     image_path: Optional[str]
+    chrome_profile: Optional[str] = "Default"
     tags: List[str]
     is_active: bool
     type: WalletType

--- a/wallets/wallet_service.py
+++ b/wallets/wallet_service.py
@@ -38,14 +38,17 @@ class WalletService:
     # 📋 List all wallets in output-safe form
     def list_wallets(self) -> List[WalletOut]:
         wallets = self.repo.get_all_wallets()
-        return [WalletOut(**w.__dict__) for w in wallets]
+        return [
+            WalletOut(**{**w.__dict__, "chrome_profile": w.chrome_profile or "Default"})
+            for w in wallets
+        ]
 
     # 🧾 Get one wallet
     def get_wallet(self, name: str) -> WalletOut:
         wallet = self.repo.get_wallet_by_name(name)
         if not wallet:
             raise ValueError(f"❌ Wallet '{name}' not found.")
-        return WalletOut(**wallet.__dict__)
+        return WalletOut(**{**wallet.__dict__, "chrome_profile": wallet.chrome_profile or "Default"})
 
     # 💾 Backup all wallets to JSON
     def export_wallets_to_json(self):
@@ -57,6 +60,8 @@ class WalletService:
         imported_count = 0
         for w in wallets:
             if not self.repo.get_wallet_by_name(w.name):
-                self.repo.add_wallet(WalletIn(**w.__dict__))
+                self.repo.add_wallet(
+                    WalletIn(**{**w.__dict__, "chrome_profile": w.chrome_profile or "Default"})
+                )
                 imported_count += 1
         return imported_count


### PR DESCRIPTION
## Summary
- extend WalletIn and WalletOut with an optional `chrome_profile` field
- propagate chrome_profile through wallet repository
- handle chrome_profile when listing or importing wallets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ed57b1048321a59ceb077eae2d09