### PR TITLE
Add wallets context to positions views

### DIFF
--- a/app/positions_bp.py
+++ b/app/positions_bp.py
@@ -64,15 +64,19 @@ def list_positions():
             pos["heat_alert_class"] = get_alert_class(heat, hi_cfg.get("low"), hi_cfg.get("medium"), hi_cfg.get("high"))
 
         totals = CalcServices().calculate_totals(positions)
+        wallets = current_app.data_locker.read_wallets()
         times = current_app.data_locker.get_last_update_times() or {}
         pos_time = _convert_iso_to_pst(times.get("last_update_time_positions", "N/A"))
 
-        return render_template("positions.html",
-                               positions=positions,
-                               totals=totals,
-                               portfolio_value=totals.get("total_value", 0),
-                               last_update_positions=pos_time,
-                               last_update_positions_source=times.get("last_update_positions_source", "N/A"))
+        return render_template(
+            "positions.html",
+            positions=positions,
+            totals=totals,
+            portfolio_value=totals.get("total_value", 0),
+            last_update_positions=pos_time,
+            last_update_positions_source=times.get("last_update_positions_source", "N/A"),
+            wallets=wallets,
+        )
 
     except Exception as e:
         log.error(f"Error in listing positions: {e}")
@@ -86,7 +90,13 @@ def positions_table():
         core = PositionCore(current_app.data_locker)
         positions = core.get_active_positions()
         totals = CalcServices().calculate_totals(positions)
-        return render_template("positions_table.html", positions=positions, totals=totals)
+        wallets = current_app.data_locker.read_wallets()
+        return render_template(
+            "positions_table.html",
+            positions=positions,
+            totals=totals,
+            wallets=wallets,
+        )
     except Exception as e:
         log.error(f"Error in positions_table: {e}")
         return jsonify({"error": str(e)}), 500

--- a/templates/liquidation_bars.html
+++ b/templates/liquidation_bars.html
@@ -6,11 +6,14 @@
     {% for pos in liquidation_positions %}
       {% if pos.travel_percent is defined and pos.travel_percent is not none %}
         <div class="liq-row">
-          <img
-            class="wallet-icon"
-            src="{{ url_for('static', filename='images/' + pos.wallet_image) }}"
-            alt="{{ pos.wallet }}"
-          />
+          {% set wallet = wallets | selectattr('name', 'equalto', pos.wallet_name) | first %}
+          <a href="/launch/{{ wallet.chrome_profile }}/{{ pos.asset_type }}">
+            <img
+              class="wallet-icon"
+              src="{{ url_for('static', filename='images/' + pos.wallet_image) }}"
+              alt="{{ pos.wallet }}"
+            />
+          </a>
 
           <div class="liq-progress-bar">
             <div class="liq-bar-container">


### PR DESCRIPTION
## Summary
- include wallet list when rendering positions views
- wrap wallet images with links to Jupiter launches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ed6eac508321a53e4f64ed3af001