### PR TITLE
Add chrome_profile DB column

### DIFF
--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -107,6 +107,7 @@ class DataLocker:
                 CREATE TABLE IF NOT EXISTS wallets (
                     name TEXT PRIMARY KEY,
                     public_address TEXT,
+                    chrome_profile TEXT DEFAULT 'Default',
                     private_address TEXT,
                     image_path TEXT,
                     balance REAL DEFAULT 0.0,
@@ -281,6 +282,7 @@ class DataLocker:
         # --- Automatic schema migrations ---
         log.debug("Applying schema migrations", source="DataLocker")
         _ensure_column(cursor, "positions", "status TEXT DEFAULT 'ACTIVE'")
+        _ensure_column(cursor, "wallets", "chrome_profile TEXT DEFAULT 'Default'")
 
         # Ensure a default row exists for system vars so lookups don't fail
         log.debug("Ensuring system_vars default row", source="DataLocker")

--- a/data/dl_wallets.py
+++ b/data/dl_wallets.py
@@ -28,13 +28,14 @@ class DLWalletManager:
             cursor.execute(
                 """
                 INSERT INTO wallets (
-                    name, public_address, private_address, image_path,
+                    name, public_address, chrome_profile, private_address, image_path,
                     balance, tags, is_active, type
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     wallet["name"],
                     wallet["public_address"],
+                    wallet.get("chrome_profile", "Default"),
                     encrypt_key(wallet.get("private_address")),
                     wallet.get("image_path", ""),
                     wallet.get("balance", 0.0),
@@ -75,6 +76,7 @@ class DLWalletManager:
                 """
                 UPDATE wallets SET
                     public_address = ?,
+                    chrome_profile = ?,
                     private_address = ?,
                     image_path = ?,
                     balance = ?,
@@ -85,6 +87,7 @@ class DLWalletManager:
             """,
                 (
                     wallet["public_address"],
+                    wallet.get("chrome_profile", "Default"),
                     encrypt_key(wallet.get("private_address")),
                     wallet.get("image_path", ""),
                     wallet.get("balance", 0.0),


### PR DESCRIPTION
## Summary
- support storing Chrome profile name for wallets
- auto-migrate wallets table on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ed5cf2a08321b604ce791dbfd24b