### PR TITLE
Handle chrome_profile in System BP wallet forms

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -131,6 +131,7 @@ def add_wallet():
         data = WalletIn(
             name=form.get("name"),
             public_address=form.get("public_address"),
+            chrome_profile=form.get("chrome_profile", "Default"),
             private_address=form.get("private_address"),
             image_path=image_path,
             balance=float(form.get("balance", 0.0)),
@@ -207,6 +208,7 @@ def update_wallet(name):
         data = WalletIn(
             name=name,
             public_address=form.get("public_address"),
+            chrome_profile=form.get("chrome_profile", "Default"),
             private_address=form.get("private_address"),
             image_path=form.get("image_path"),
             balance=float(form.get("balance", 0.0)),

--- a/wallets/wallet_schema.py
+++ b/wallets/wallet_schema.py
@@ -35,6 +35,7 @@ class WalletType(str, Enum):
 class WalletIn(BaseModel):
     name: str = Field(..., example="VaderVault", description="Unique wallet name")
     public_address: str = Field(..., example="0xABC123...", description="Public wallet address")
+    chrome_profile: Optional[str] = None
     private_address: Optional[str] = Field(None, description="Optional private key (only for dev)")
     image_path: Optional[str] = Field(None, example="/static/img/vader.png")
     balance: float = Field(0.0, ge=0.0)
@@ -46,6 +47,7 @@ class WalletIn(BaseModel):
 class WalletOut(BaseModel):
     name: str
     public_address: str
+    chrome_profile: Optional[str] = None
     balance: float
     image_path: Optional[str]
     tags: List[str]


### PR DESCRIPTION
## Summary
- collect `chrome_profile` from wallet forms in the System blueprint
- include the field in `WalletIn`/`WalletOut` schemas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ed647d108321b6e86a99f3f74a2f