### PR TITLE
Add Chrome profile input to wallet forms

### DIFF
--- a/templates/wallets/wallet_form.html
+++ b/templates/wallets/wallet_form.html
@@ -12,6 +12,10 @@
         <input type="text" name="public_address" id="public_address" class="form-control" required>
       </div>
       <div class="mb-3">
+        <label for="chrome_profile" class="form-label">Chrome Profile:</label>
+        <input type="text" name="chrome_profile" id="chrome_profile" class="form-control" placeholder="Default">
+      </div>
+      <div class="mb-3">
         <label for="private_address" class="form-label">Private Address:</label>
         <input type="text" name="private_address" id="private_address" class="form-control">
       </div>

--- a/templates/wallets/wallet_manager.html
+++ b/templates/wallets/wallet_manager.html
@@ -95,7 +95,8 @@
                       data-tags="{{ wallet.tags|join(', ') }}"
                       data-type="{{ wallet.type }}"
                       data-active="{{ wallet.is_active }}"
-                      data-image="{{ wallet.image_path }}">
+                      data-image="{{ wallet.image_path }}"
+                      data-chrome="{{ wallet.chrome_profile }}">
                 ✏️
               </button>
             </div>
@@ -222,6 +223,10 @@
               <input type="text" name="public_address" id="edit_public" class="form-control">
             </div>
             <div class="col-md-6">
+              <label class="form-label">Chrome Profile:</label>
+              <input type="text" name="chrome_profile" id="edit_chrome" class="form-control" placeholder="Default">
+            </div>
+            <div class="col-md-6">
               <label class="form-label">Private Address:</label>
               <input type="text" name="private_address" id="edit_private" class="form-control">
             </div>
@@ -276,6 +281,7 @@
         form.action = btn.dataset.updateUrl;
         document.getElementById('edit_name').value = btn.dataset.name;
         document.getElementById('edit_public').value = btn.dataset.public;
+        document.getElementById('edit_chrome').value = btn.dataset.chrome || '';
         document.getElementById('edit_private').value = btn.dataset.private;
         document.getElementById('edit_balance').value = btn.dataset.balance;
         document.getElementById('edit_tags').value = btn.dataset.tags;


### PR DESCRIPTION
## Summary
- allow specifying Chrome profile when creating a wallet
- populate Chrome profile in the wallet edit modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ed68c9f08321a08f90db2d4900bb