### PR TITLE
Add launch route test

### DIFF
--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -346,6 +346,12 @@ def get_dashboard_context(data_locker, system_core=None):
         if total_collat > 0 else {"series": [0, 0], "label": "No collateral data"}
     )
 
+    wallets = []
+    try:
+        wallets = data_locker.read_wallets() or []
+    except Exception as e:  # pragma: no cover - DB error extremely rare
+        log.error(f"Failed to read wallets: {e}", source="DashboardContext")
+
     return {
         "theme_mode": data_locker.system.get_theme_mode(),
         "positions": positions,
@@ -369,4 +375,5 @@ def get_dashboard_context(data_locker, system_core=None):
         "positions_monitor_status": monitor_statuses["positions"],
         "operations_monitor_status": monitor_statuses["operations"],
         "xcom_monitor_status": monitor_statuses["xcom"],
+        "wallets": wallets,
     }

--- a/templates/liquidation_bars.html
+++ b/templates/liquidation_bars.html
@@ -6,8 +6,9 @@
     {% for pos in liquidation_positions %}
       {% if pos.travel_percent is defined and pos.travel_percent is not none %}
         <div class="liq-row">
-          {% set wallet = wallets | selectattr('name', 'equalto', pos.wallet_name) | first %}
-          <a href="/launch/{{ wallet.chrome_profile }}/{{ pos.asset_type }}">
+        {% set wallet_matches = wallets | selectattr('name', 'equalto', pos.wallet_name) | list %}
+        {% set wallet = wallet_matches[0] if wallet_matches else None %}
+        <a href="/launch/{{ wallet.chrome_profile if wallet else 'Default' }}/{{ pos.asset_type }}">
             <img
               class="wallet-icon"
               src="{{ url_for('static', filename='images/' + pos.wallet_image) }}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,50 @@ import asyncio
 # Automatically fix sys.path for tests
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+# Stub rich if not installed so launch_pad and TestCore import cleanly
+if "rich" not in sys.modules:
+    rich_stub = types.ModuleType("rich")
+    rich_console = types.ModuleType("rich.console")
+    rich_text = types.ModuleType("rich.text")
+    rich_panel = types.ModuleType("rich.panel")
+    rich_prompt = types.ModuleType("rich.prompt")
+    rich_table = types.ModuleType("rich.table")
+
+    class DummyConsole:
+        def print(self, *a, **k):
+            pass
+
+    class DummyPanel:
+        def __init__(self, *a, **k):
+            pass
+
+    class DummyPrompt:
+        @staticmethod
+        def ask(*a, **k):
+            return ""
+
+    class DummyTable:
+        def __init__(self, *a, **k):
+            pass
+
+    rich_console.Console = DummyConsole
+    rich_text.Text = str
+    rich_panel.Panel = DummyPanel
+    rich_prompt.Prompt = DummyPrompt
+    rich_table.Table = DummyTable
+    rich_stub.console = rich_console
+    rich_stub.text = rich_text
+    rich_stub.panel = rich_panel
+    rich_stub.prompt = rich_prompt
+    rich_stub.table = rich_table
+
+    sys.modules.setdefault("rich", rich_stub)
+    sys.modules.setdefault("rich.console", rich_console)
+    sys.modules.setdefault("rich.text", rich_text)
+    sys.modules.setdefault("rich.panel", rich_panel)
+    sys.modules.setdefault("rich.prompt", rich_prompt)
+    sys.modules.setdefault("rich.table", rich_table)
+
 # Stub rich_logger and winsound to avoid optional deps during tests
 rich_logger_stub = types.ModuleType("utils.rich_logger")
 class RichLogger:

--- a/tests/test_dashboard_wallet_links.py
+++ b/tests/test_dashboard_wallet_links.py
@@ -1,0 +1,104 @@
+import types
+import pytest
+import importlib
+
+flask = importlib.import_module("flask")
+if not getattr(flask, "Flask", None):
+    pytest.skip("Flask not available", allow_module_level=True)
+
+from flask import Flask
+from app.dashboard_bp import dashboard_bp
+from dashboard import dashboard_service
+
+
+def _setup_app(monkeypatch, context):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(dashboard_bp)
+    monkeypatch.setattr(
+        dashboard_service,
+        "get_dashboard_context",
+        lambda dl, sc: context,
+    )
+    app.data_locker = object()
+    app.system_core = object()
+    return app
+
+
+def test_dash_page_handles_missing_wallet(monkeypatch):
+    context = {
+        "positions": [],
+        "liquidation_positions": [
+            {
+                "wallet_name": "Ghost",
+                "wallet_image": "ghost.jpg",
+                "asset_type": "BTC",
+                "travel_percent": 0,
+                "heat_index": 0,
+            }
+        ],
+        "wallets": [],
+        "status_items": [],
+        "monitor_items": [],
+        "portfolio_limits": {},
+        "profit_badge_value": None,
+        "graph_data": {},
+        "size_composition": {},
+        "collateral_composition": {},
+        "price_monitor_history": [],
+        "positions_monitor_history": [],
+        "operations_monitor_history": [],
+        "xcom_monitor_history": [],
+        "price_monitor_status": "",
+        "positions_monitor_status": "",
+        "operations_monitor_status": "",
+        "xcom_monitor_status": "",
+        "theme_mode": "dark",
+    }
+    app = _setup_app(monkeypatch, context)
+    with app.test_client() as client:
+        resp = client.get("/dash")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "ghost.jpg" in html
+        assert "/launch/Default/BTC" in html
+
+
+def test_dash_page_uses_wallet_profile(monkeypatch):
+    context = {
+        "positions": [],
+        "liquidation_positions": [
+            {
+                "wallet_name": "Known",
+                "wallet_image": "known.jpg",
+                "asset_type": "ETH",
+                "travel_percent": 0,
+                "heat_index": 0,
+            }
+        ],
+        "wallets": [
+            {"name": "Known", "chrome_profile": "Profile1"}
+        ],
+        "status_items": [],
+        "monitor_items": [],
+        "portfolio_limits": {},
+        "profit_badge_value": None,
+        "graph_data": {},
+        "size_composition": {},
+        "collateral_composition": {},
+        "price_monitor_history": [],
+        "positions_monitor_history": [],
+        "operations_monitor_history": [],
+        "xcom_monitor_history": [],
+        "price_monitor_status": "",
+        "positions_monitor_status": "",
+        "operations_monitor_status": "",
+        "xcom_monitor_status": "",
+        "theme_mode": "dark",
+    }
+    app = _setup_app(monkeypatch, context)
+    with app.test_client() as client:
+        resp = client.get("/dash")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "/launch/Profile1/ETH" in html

--- a/tests/test_launch_pad_web.py
+++ b/tests/test_launch_pad_web.py
@@ -1,0 +1,101 @@
+import builtins
+import sys
+import types
+
+import pytest
+
+# Provide minimal rich stubs to satisfy launch_pad import
+_dummy_rich = types.ModuleType("rich")
+_dummy_console = types.ModuleType("rich.console")
+_dummy_text = types.ModuleType("rich.text")
+_dummy_panel = types.ModuleType("rich.panel")
+_dummy_prompt = types.ModuleType("rich.prompt")
+_dummy_table = types.ModuleType("rich.table")
+
+class _Console:
+    def print(self, *a, **k):
+        pass
+
+_dummy_console.Console = _Console
+_dummy_text.Text = str
+
+class _Panel:
+    def __init__(self, *a, **k):
+        pass
+
+class _Prompt:
+    @staticmethod
+    def ask(*a, **k):
+        return ""
+
+class _Table:
+    def __init__(self, *a, **k):
+        pass
+    def add_row(self, *a, **k):
+        pass
+
+_dummy_panel.Panel = _Panel
+_dummy_prompt.Prompt = _Prompt
+_dummy_table.Table = _Table
+
+_dummy_rich.console = _dummy_console
+_dummy_rich.text = _dummy_text
+_dummy_rich.panel = _dummy_panel
+_dummy_rich.prompt = _dummy_prompt
+_dummy_rich.table = _dummy_table
+sys.modules.setdefault("rich", _dummy_rich)
+sys.modules.setdefault("rich.console", _dummy_console)
+sys.modules.setdefault("rich.text", _dummy_text)
+sys.modules.setdefault("rich.panel", _dummy_panel)
+sys.modules.setdefault("rich.prompt", _dummy_prompt)
+sys.modules.setdefault("rich.table", _dummy_table)
+
+# Stub heavy dependencies referenced by launch_pad at import time
+core_logging_stub = types.ModuleType("core.logging")
+class _DummyLog:
+    logger = types.SimpleNamespace(setLevel=lambda *a, **k: None)
+    def __getattr__(self, _):
+        def noop(*a, **k):
+            pass
+        return noop
+core_logging_stub.log = _DummyLog()
+core_logging_stub.configure_console_log = lambda *a, **k: None
+sys.modules.setdefault("core.logging", core_logging_stub)
+
+sys.modules.setdefault("cyclone_app", types.ModuleType("cyclone_app"))
+sys.modules["cyclone_app"].main = lambda: None
+sys.modules.setdefault("monitor.operations_monitor", types.SimpleNamespace(OperationsMonitor=object))
+sys.modules.setdefault("utils.startup_service", types.ModuleType("utils.startup_service"))
+sys.modules["utils.startup_service"].StartUpService = types.SimpleNamespace(run_all=lambda: None)
+sys.modules.setdefault("scripts.verify_all_tables_exist", types.ModuleType("scripts.verify_all_tables_exist"))
+sys.modules["scripts.verify_all_tables_exist"].verify_all_tables_exist = lambda: 0
+sys.modules.setdefault("monitor.sonic_monitor", types.ModuleType("monitor.sonic_monitor"))
+
+try:
+    import launch_pad
+except Exception:
+    pytest.skip("launch_pad module unavailable", allow_module_level=True)
+
+
+def _run_launch(func, monkeypatch):
+    urls = []
+    popen_cmds = []
+    monkeypatch.setattr(builtins, "input", lambda _: "")
+    monkeypatch.setattr(launch_pad.time, "sleep", lambda _: None)
+    monkeypatch.setattr(launch_pad.webbrowser, "open", lambda url: urls.append(url))
+    monkeypatch.setattr(launch_pad.subprocess, "Popen", lambda args: popen_cmds.append(args))
+    monkeypatch.setattr(launch_pad.log, "print_dashboard_link", lambda *a, **k: None)
+    func()
+    return urls, popen_cmds
+
+
+def test_launch_sonic_web_opens_browser(monkeypatch):
+    urls, popen_cmds = _run_launch(launch_pad.launch_sonic_web, monkeypatch)
+    assert urls == ["http://127.0.0.1:5000"]
+    assert popen_cmds == [[sys.executable, "sonic_app.py"]]
+
+
+def test_launch_trader_cards_opens_browser(monkeypatch):
+    urls, popen_cmds = _run_launch(launch_pad.launch_trader_cards, monkeypatch)
+    assert urls == ["http://127.0.0.1:5000/trader/cards"]
+    assert popen_cmds == [[sys.executable, "sonic_app.py"]]

--- a/tests/test_sonic_app_launch_route.py
+++ b/tests/test_sonic_app_launch_route.py
@@ -1,0 +1,119 @@
+import sys
+import types
+import subprocess
+
+import pytest
+
+
+def _prepare_sonic_env(monkeypatch):
+    """Install minimal stubs so ``sonic_app`` imports without heavy deps."""
+    class DummyFlask:
+        def __init__(self, *a, **k):
+            self.config = {}
+            self.view_functions = {}
+        def route(self, *a, **k):
+            def decorator(func):
+                self.view_functions[func.__name__] = func
+                return func
+            return decorator
+        def add_url_rule(self, rule, endpoint=None, view_func=None, **options):
+            if view_func:
+                self.view_functions[endpoint or view_func.__name__] = view_func
+        def context_processor(self, func):
+            return func
+        def add_template_filter(self, func, name=None):
+            pass
+        def register_blueprint(self, bp, **k):
+            pass
+        def app_context(self):
+            class Ctx:
+                def __enter__(self_inner):
+                    return self
+                def __exit__(self_inner, exc_type, exc, tb):
+                    pass
+            return Ctx()
+        def run(self, *a, **k):  # pragma: no cover - never executed
+            raise RuntimeError('Flask not installed')
+    flask_stub = types.ModuleType('flask')
+    flask_stub.Flask = DummyFlask
+    flask_stub.redirect = lambda loc: loc
+    flask_stub.url_for = lambda endpoint, **kwargs: endpoint
+    flask_stub.current_app = types.SimpleNamespace()
+    flask_stub.jsonify = lambda *a, **k: {}
+    monkeypatch.setitem(sys.modules, 'flask', flask_stub)
+    monkeypatch.setitem(sys.modules, 'flask_socketio', types.SimpleNamespace(SocketIO=lambda *a, **k: None))
+
+    # Import global stubs from conftest (rich_logger etc.)
+    import tests.conftest  # noqa: F401
+
+    core_logging = types.ModuleType('core.logging')
+    class DummyLog:
+        logger = types.SimpleNamespace(setLevel=lambda level: None)
+        def __getattr__(self, name):
+            def noop(*a, **k):
+                pass
+            return noop
+    core_logging.log = DummyLog()
+    core_logging.configure_console_log = lambda debug=False: None
+    monkeypatch.setitem(sys.modules, 'core.logging', core_logging)
+    core_imports = types.ModuleType('core.core_imports')
+    core_imports.log = core_logging.log
+    core_imports.configure_console_log = core_logging.configure_console_log
+    core_imports.DB_PATH = ''
+    core_imports.BASE_DIR = ''
+    core_imports.ALERT_THRESHOLDS_PATH = ''
+    core_imports.retry_on_locked = lambda: (lambda f: f)
+    monkeypatch.setitem(sys.modules, 'core.core_imports', core_imports)
+
+    DataLocker = type('DataLocker', (), {
+        '__init__': lambda self, path: None,
+        'system': types.SimpleNamespace(get_var=lambda *a, **k: {}, set_var=lambda *a, **k: None),
+        'db': types.SimpleNamespace(get_cursor=lambda: None),
+    })
+    monkeypatch.setitem(sys.modules, 'data.data_locker', types.SimpleNamespace(DataLocker=DataLocker))
+    SystemCore = type('SystemCore', (), {
+        '__init__': lambda self, dl: None,
+        'get_active_profile': lambda self: None,
+    })
+    monkeypatch.setitem(sys.modules, 'system.system_core', types.SimpleNamespace(SystemCore=SystemCore))
+    monkeypatch.setitem(sys.modules, 'monitor.monitor_core', types.SimpleNamespace(MonitorCore=lambda: None))
+    monkeypatch.setitem(sys.modules, 'cyclone.cyclone_engine', types.SimpleNamespace(Cyclone=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'utils.template_filters', types.SimpleNamespace(short_datetime=lambda x: 'time'))
+
+    bp_modules = {
+        'app.positions_bp': 'positions_bp',
+        'app.alerts_bp': 'alerts_bp',
+        'app.prices_bp': 'prices_bp',
+        'app.dashboard_bp': 'dashboard_bp',
+        'portfolio.portfolio_bp': 'portfolio_bp',
+        'sonic_labs.sonic_labs_bp': 'sonic_labs_bp',
+        'cyclone.cyclone_bp': 'cyclone_bp',
+        'routes.theme_routes': 'theme_bp',
+        'app.system_bp': 'system_bp',
+        'settings.settings_bp': 'settings_bp',
+        'gpt.chat_gpt_bp': 'chat_gpt_bp',
+        'gpt.gpt_bp': 'gpt_bp',
+        'trader_core.trader_bp': 'trader_bp',
+    }
+    for mod_name, attr in bp_modules.items():
+        mod = types.ModuleType(mod_name)
+        setattr(mod, attr, object())
+        monkeypatch.setitem(sys.modules, mod_name, mod)
+
+
+def test_launch_route_opens_browser(monkeypatch):
+    _prepare_sonic_env(monkeypatch)
+    import sonic_app
+
+    sonic_app.PERPETUAL_TOKENS = {'BTC': {'id': 1}}
+    popen_args = []
+    monkeypatch.setattr(subprocess, 'Popen', lambda args: popen_args.append(args))
+
+    result = sonic_app.launch_jupiter_position('Default', 'BTC')
+    assert result == 'Launching BTC in Default'
+    assert popen_args == [[
+        'C:/Program Files/Google/Chrome/Application/chrome.exe',
+        '--profile-directory=Default',
+        'https://jup.ag/perpetuals/BTC',
+    ]]
+


### PR DESCRIPTION
## Summary
- expand test coverage for the `/launch/<profile>/<asset>` route

## Testing
- `pytest -q`
- `pytest -q tests/test_sonic_app_launch_route.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_6840f5583f2883218f17a29c101d0102