### PR TITLE
Fix duplicate format_monitor_time

### DIFF
--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -108,18 +108,6 @@ def apply_color(metric_name, value, limits):
         return "red"
 
 import json
-from datetime import datetime
-from zoneinfo import ZoneInfo
-
-def format_monitor_time(iso_str):
-    if not iso_str:
-        return "N/A"
-    try:
-        dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
-        pacific = dt.astimezone(ZoneInfo("America/Los_Angeles"))
-        return pacific.strftime("%I:%M %p\n%m/%d").lstrip("0")
-    except Exception as e:
-        return "N/A"
 
 def format_short_time(iso_str):
     if not iso_str:


### PR DESCRIPTION
## Summary
- clean up dashboard_service imports
- remove duplicate `format_monitor_time` definition

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840fdef0560832187eb9546f7b2500e