### PR TITLE
Tweak positions table layout

### DIFF
--- a/templates/positions_table.html
+++ b/templates/positions_table.html
@@ -79,7 +79,7 @@
   background: #222e3a;
   color: #fff;
   font-weight: 700;
-  padding: 0.7em 0.6em;
+  padding: 0.55em 0.5em;
   border-bottom: 2px solid #c0d7f5;
   user-select: none;
   cursor: pointer;
@@ -94,7 +94,7 @@
 .positions-table tbody td {
   background: var(--container-bg);
   color: #111;
-  padding: 0.7em 0.6em;
+  padding: 0.55em 0.5em;
   border-bottom: 1px solid #e6ecf8;
   vertical-align: middle;
 }
@@ -109,8 +109,8 @@
 .positions-table tfoot th.left { text-align: left; }
 
 .asset-icon {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
   object-fit: cover;
   display: inline-block;


### PR DESCRIPTION
## Summary
- reduce cell padding for smaller row height
- shrink asset icons in the dashboard positions table

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'render_template_string' from 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841905144a88321804ac2e989f5cebc