### PR TITLE
Add totals row to trader shop leaderboard

### DIFF
--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -130,6 +130,29 @@ function loadTraders() {
         }
       });
 
+      if (leaderboard) {
+        const footer = document.getElementById('leaderboard-footer');
+        if (footer) footer.innerHTML = '';
+
+        const count = sorted.length;
+        const totalScore = sorted.reduce((sum, t) => sum + (t.performance_score ?? 0), 0);
+        const totalBalance = sorted.reduce((sum, t) => sum + (t.wallet_balance ?? 0), 0);
+        const totalHeat = sorted.reduce((sum, t) => sum + (t.heat_index ?? 0), 0);
+
+        const avgScore = count ? (totalScore / count) : 0;
+        const avgHeat = count ? (totalHeat / count) : 0;
+
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>Totals</td>
+          <td>${avgScore.toFixed(2)}</td>
+          <td>$${totalBalance.toFixed(2)}</td>
+          <td>${avgHeat.toFixed(1)}</td>
+          <td>-</td>
+        `;
+        if (footer) footer.appendChild(row);
+      }
+
       data.traders.forEach(trader => {
         const card = document.createElement("div");
         card.className = "trader-card" + ((trader.performance_score ?? 0) === topScore ? " top-score" : "");

--- a/templates/trader_shop.html
+++ b/templates/trader_shop.html
@@ -91,6 +91,9 @@
           <tbody id="leaderboard-body">
             <!-- Leaderboard rows will be inserted here -->
           </tbody>
+          <tfoot id="leaderboard-footer" class="fw-bold">
+            <!-- Totals row will be inserted here -->
+          </tfoot>
         </table>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add empty leaderboard footer row in `trader_shop.html`
- compute averages and totals in `trader_shop.js`

## Testing
- `pytest -q` *(fails: ImportError and TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6841928fb5088321bb68c9663cac1883