### PR TITLE
Add avatar icons to leaderboard

### DIFF
--- a/static/css/trader_shop.css
+++ b/static/css/trader_shop.css
@@ -61,3 +61,15 @@
   background: var(--accent, #e0e0e0);
   font-size: 2rem;
 }
+
+/* Smaller avatar used in leaderboard */
+.leader-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: inline-block;
+  text-align: center;
+  line-height: 32px;
+  font-size: 1.2rem;
+}

--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -119,7 +119,16 @@ function loadTraders() {
       sorted.forEach(trader => {
         if (leaderboard) {
           const row = document.createElement('tr');
+
+          let avatarHTML = '';
+          if (trader.avatar?.startsWith('/static/')) {
+            avatarHTML = `<img src="${trader.avatar}" class="leader-avatar">`;
+          } else if (trader.avatar) {
+            avatarHTML = `<span class="leader-avatar">${trader.avatar}</span>`;
+          }
+
           row.innerHTML = `
+            <td>${avatarHTML}</td>
             <td>${trader.name}</td>
             <td>${trader.performance_score ?? '?'}</td>
             <td>$${trader.wallet_balance?.toFixed(2) ?? '0.00'}</td>
@@ -144,6 +153,7 @@ function loadTraders() {
 
         const row = document.createElement('tr');
         row.innerHTML = `
+          <td></td>
           <td>Totals</td>
           <td>${avgScore.toFixed(2)}</td>
           <td>$${totalBalance.toFixed(2)}</td>

--- a/templates/trader_shop.html
+++ b/templates/trader_shop.html
@@ -81,6 +81,7 @@
         <table class="table table-striped">
           <thead>
             <tr>
+              <th>Avatar</th>
               <th>Name</th>
               <th>Score</th>
               <th>Balance</th>


### PR DESCRIPTION
## Summary
- show avatar icons in leaderboard table
- style leaderboard avatar images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', TypeError: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6841951bd8088321a7f9218763d32310