### PR TITLE
Add birth info to Trader dataclass

### DIFF
--- a/trader_core/trader.py
+++ b/trader_core/trader.py
@@ -10,6 +10,8 @@ class Trader:
     persona: str = ""
     origin_story: str = ""
     risk_profile: str = ""
+    born_on: str = ""
+    initial_collateral: float = 0.0
     mood: str = "neutral"
     moods: Dict[str, str] = field(default_factory=dict)
     strategies: Dict[str, float] = field(default_factory=dict)
@@ -25,5 +27,6 @@ class Trader:
     def __repr__(self) -> str:
         return (
             f"Trader(name={self.name!r}, persona={self.persona!r}, mood={self.mood!r}, "
+            f"born_on={self.born_on!r}, initial_collateral={self.initial_collateral}, "
             f"heat_index={self.heat_index}, wallet_balance={self.wallet_balance}, profit={self.profit})"
         )


### PR DESCRIPTION
## Summary
- extend `Trader` dataclass with `born_on` and `initial_collateral`
- show these fields in `Trader.__repr__`

## Testing
- `pytest -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68423a9a5be8832191f34d5c5c9a7c16