### PR TITLE
Add born_on and collateral info to Trader creation

### DIFF
--- a/trader_core/trader.py
+++ b/trader_core/trader.py
@@ -21,6 +21,8 @@ class Trader:
     hedges: List[Dict] = field(default_factory=list)
     performance_score: int = 0
     heat_index: float = 0.0
+    born_on: str = ""
+    initial_collateral: float = 0.0
 
     def __repr__(self) -> str:
         return (

--- a/trader_core/trader_core.py
+++ b/trader_core/trader_core.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 from trader_core.trader import Trader
 from trader_core.mood_engine import evaluate_mood
 from trader_core.trader_store import TraderStore
+from datetime import datetime
 
 StrategyManager = importlib.import_module("oracle_core.strategy_manager").StrategyManager
 PersonaManager = importlib.import_module("oracle_core.persona_manager").PersonaManager
@@ -54,6 +55,10 @@ class TraderCore:
         score = max(0, int(100 - avg_heat))
         total_balance = sum(float(p.get("value") or 0.0) for p in positions)
         total_profit = sum(calc.calculate_profit(p) for p in positions)
+        born_on = datetime.now().isoformat()
+        initial_collateral = (
+            wallet_data.get("balance", 0.0) if isinstance(wallet_data, dict) else 0.0
+        )
         trader = Trader(
             name=persona.name,
             avatar=getattr(persona, "avatar", ""),
@@ -71,6 +76,8 @@ class TraderCore:
             hedges=[],
             performance_score=score,
             heat_index=avg_heat,
+            born_on=born_on,
+            initial_collateral=initial_collateral,
         )
         return trader
 

--- a/trader_core/trader_loader.py
+++ b/trader_core/trader_loader.py
@@ -1,6 +1,7 @@
 """Utility to build Trader objects from live data."""
 
 from typing import Optional
+from datetime import datetime
 
 import importlib
 
@@ -42,6 +43,10 @@ class TraderLoader:
         avg_heat = calc.calculate_weighted_heat_index(positions)
         mood = evaluate_mood(avg_heat, getattr(persona, "moods", {}))
         score = max(0, int(100 - avg_heat))
+        born_on = datetime.now().isoformat()
+        initial_collateral = (
+            wallet_data.get("balance", 0.0) if isinstance(wallet_data, dict) else 0.0
+        )
         return Trader(
             name=persona.name,
             avatar=getattr(persona, "avatar", ""),
@@ -57,4 +62,6 @@ class TraderLoader:
             hedges=[],
             performance_score=score,
             heat_index=avg_heat,
+            born_on=born_on,
+            initial_collateral=initial_collateral,
         )


### PR DESCRIPTION
## Summary
- track born date and starting collateral on Trader instances
- propagate these new attributes through TraderCore and TraderLoader

## Testing
- `pytest tests/test_trader_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68423a9ed364832180e09108b5fa17e5