### PR TITLE
Add initial collateral field to trader form

### DIFF
--- a/templates/trader_shop.html
+++ b/templates/trader_shop.html
@@ -60,6 +60,10 @@
               </div>
             </div>
             <div class="mb-2">
+              <label for="initialCollateralInput" class="form-label">Initial Collateral</label>
+              <input type="number" class="form-control" id="initialCollateralInput" name="initial_collateral" placeholder="Initial Collateral">
+            </div>
+            <div class="mb-2">
               <label for="walletSelect" class="form-label">Wallet</label>
               <select name="wallet" class="form-select" id="walletSelect"></select>
             </div>


### PR DESCRIPTION
## Summary
- add a numeric `initial_collateral` input to the trader creation form

## Testing
- `pytest -q` *(fails: TypeError and AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68423aa2edd48321acdde117679bfc6d