### PR TITLE
Add birthdate and collateral to trader cards

### DIFF
--- a/static/css/trader_shop.css
+++ b/static/css/trader_shop.css
@@ -2,7 +2,7 @@
   --border-width: 1px;
   --border-color: #d0d0d0;
   width: 200px;
-  height: 250px;
+  height: 300px;
   border: var(--border-width) solid var(--border-color);
   border-radius: 8px;
   perspective: 1000px;

--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -225,6 +225,8 @@ function loadTraders() {
             <div class="card-back">
               <p>Score: ${trader.performance_score ?? "?"}</p>
               <p>Strategy Count: ${Object.keys(trader.strategies || {}).length}</p>
+              <p>Born on: ${trader.born_on ? new Date(trader.born_on).toLocaleString() : 'N/A'}</p>
+              <p>Initial Collateral: $${(trader.initial_collateral ?? 0).toFixed(2)}</p>
               <button class="btn btn-danger btn-sm mt-2" onclick="deleteTrader('${trader.name}')">Delete</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- show trader birthdate and initial collateral in trader cards
- enlarge trader card height to fit new lines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68423aa70d1c83219fad207bf7355f09