### PR TITLE
Update wallet panel with bulk actions

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -182,18 +182,13 @@ def import_wallets():
     return redirect(url_for("system.list_wallets"))
 
 
-# 💉 Inject wallets from backup JSON using insert_wallets script
+# ✨ Inject Star Wars wallets via WalletCore
 @system_bp.route("/wallets/inject", methods=["POST"])
 def inject_wallets():
-    """Run the wallet DB injection script."""
+    """Insert themed wallets using ``WalletCore.insert_star_wars_wallets``."""
     try:
-        from scripts.insert_wallets import main as insert_wallets_main
-
-        result = insert_wallets_main([])
-        if result == 0:
-            flash("💉 Wallets injected from backup.", "success")
-        else:
-            flash("⚠️ Wallet injection completed with errors.", "warning")
+        count = get_core().wallet_core.insert_star_wars_wallets()
+        flash(f"✨ Injected {count} wallets from a galaxy far, far away.", "success")
     except Exception as e:  # pragma: no cover - best effort
         flash(f"❌ Wallet injection failed: {e}", "danger")
     return redirect(url_for("system.list_wallets"))
@@ -253,6 +248,16 @@ def withdraw_collateral():
         flash(f"✅ Withdraw transaction sent: {sig}", "success")
     except Exception as e:
         flash(f"❌ Withdraw failed: {e}", "danger")
+    return redirect(url_for("system.list_wallets"))
+
+# 🗑️ Delete all wallets
+@system_bp.route("/wallets/delete_all", methods=["POST"])
+def delete_all_wallets():
+    try:
+        get_core().wallet_core.delete_all_wallets()
+        flash("🧹 All wallets deleted.", "info")
+    except Exception as e:
+        flash(f"❌ Failed to delete wallets: {e}", "danger")
     return redirect(url_for("system.list_wallets"))
 
 

--- a/data/dl_wallets.py
+++ b/data/dl_wallets.py
@@ -134,3 +134,13 @@ class DLWalletManager:
             log.info(f"Wallet deleted: {name}", source="DLWalletManager")
         except Exception as e:
             log.error(f"Failed to delete wallet {name}: {e}", source="DLWalletManager")
+
+    def delete_all_wallets(self):
+        """Remove all wallet records from the database."""
+        try:
+            cursor = self.db.get_cursor()
+            cursor.execute("DELETE FROM wallets")
+            self.db.commit()
+            log.success("🧹 All wallets deleted", source="DLWalletManager")
+        except Exception as e:
+            log.error(f"Failed to delete all wallets: {e}", source="DLWalletManager")

--- a/scripts/insert_star_wars_wallets.py
+++ b/scripts/insert_star_wars_wallets.py
@@ -11,23 +11,32 @@ sys.path.append(r'C:\alpha')
 from wallets.wallet_core import WalletCore
 from wallets.wallet import Wallet
 
-with open(wallet_json_path, 'r') as file:
-    data = json.load(file)
 
-wallet_core = WalletCore()
-1
-for wallet_info in data['wallets']:
-    wallet = Wallet(
-        name=wallet_info['name'],
-        public_address=wallet_info['public'],
-        private_address=wallet_info.get('private_key'),
-        image_path=wallet_info['image'],
-        tags=["star_wars", "imported"],
-        is_active=True,
-        type="personal"
-    )
+def insert_star_wars_wallets() -> int:
+    """Insert Star Wars wallets defined in ``wallet_json_path``."""
+    with open(wallet_json_path, 'r') as file:
+        data = json.load(file)
 
-    wallet_core.service.create_wallet(wallet)
-    print(f"Inserted wallet: {wallet.name}")
+    wallet_core = WalletCore()
+    inserted = 0
+    for wallet_info in data['wallets']:
+        wallet = Wallet(
+            name=wallet_info['name'],
+            public_address=wallet_info['public'],
+            private_address=wallet_info.get('private_key'),
+            image_path=wallet_info['image'],
+            tags=["star_wars", "imported"],
+            is_active=True,
+            type="personal"
+        )
 
-print("All wallets have been inserted into the database.")
+        wallet_core.service.create_wallet(wallet)
+        inserted += 1
+        print(f"Inserted wallet: {wallet.name}")
+
+    print("All wallets have been inserted into the database.")
+    return inserted
+
+
+if __name__ == "__main__":
+    insert_star_wars_wallets()

--- a/templates/wallets/wallet_manager.html
+++ b/templates/wallets/wallet_manager.html
@@ -50,9 +50,6 @@
   <div class="sonic-content-panel">
     <div class="d-flex justify-content-between align-items-center mb-2">
       <div class="section-title mb-0">Wallets</div>
-      <form action="{{ url_for('system.inject_wallets') }}" method="post" class="d-inline">
-        <button type="submit" class="btn btn-sm btn-secondary" title="Inject Wallets">💉</button>
-      </form>
     </div>
     <div class="mini-table-box mb-4">
       <table class="table table-striped align-middle mb-0 wallet-table">
@@ -192,7 +189,7 @@
   <div class="sonic-content-panel">
     {% include "wallets/wallet_form.html" %}
 
-    <div class="mt-4">
+    <div class="mt-4 d-flex justify-content-between align-items-center">
       <form action="{{ url_for('system.export_wallets') }}" method="post" class="d-inline">
         <button type="submit" class="btn btn-secondary">💾 Export to JSON</button>
       </form>
@@ -200,7 +197,11 @@
         <button type="submit" class="btn btn-secondary">♻️ Import from JSON</button>
       </form>
       <form action="{{ url_for('system.inject_wallets') }}" method="post" class="d-inline">
-        <button type="submit" class="btn btn-secondary" title="Inject Wallets">💉</button>
+        <button type="submit" class="btn btn-secondary" title="Inject Wallets">✨</button>
+      </form>
+      <form action="{{ url_for('system.delete_all_wallets') }}" method="post" class="ms-auto">
+        <button type="submit" class="btn btn-danger"
+                onclick="return confirm('Delete all wallets?') && confirm('This cannot be undone. Continue?')">🗑️ Delete All</button>
       </form>
     </div>
   </div>

--- a/wallets/wallet_core.py
+++ b/wallets/wallet_core.py
@@ -249,3 +249,21 @@ class WalletCore:
             log.error(f"Trigger order failed for {wallet.name}: {e}", source="WalletCore")
             return None
 
+    def insert_star_wars_wallets(self) -> int:
+        """Load Star Wars themed wallets via the helper script."""
+        try:
+            from scripts.insert_star_wars_wallets import insert_star_wars_wallets
+
+            return insert_star_wars_wallets()
+        except Exception as e:  # pragma: no cover - best effort
+            log.error(f"Failed to inject Star Wars wallets: {e}", source="WalletCore")
+            return 0
+
+    def delete_all_wallets(self) -> None:
+        """Remove all wallets from persistent storage."""
+        try:
+            self.service.delete_all_wallets()
+            log.success("All wallets deleted via WalletCore", source="WalletCore")
+        except Exception as e:
+            log.error(f"Failed to delete all wallets: {e}", source="WalletCore")
+

--- a/wallets/wallet_repository.py
+++ b/wallets/wallet_repository.py
@@ -82,3 +82,7 @@ class WalletRepository:
             Wallet(**{**item, "chrome_profile": item.get("chrome_profile", "Default")})
             for item in data
         ]
+
+    def delete_all_wallets(self) -> None:
+        """Remove all wallets from the database."""
+        self.dl.wallets.delete_all_wallets()

--- a/wallets/wallet_service.py
+++ b/wallets/wallet_service.py
@@ -65,3 +65,7 @@ class WalletService:
                 )
                 imported_count += 1
         return imported_count
+
+    def delete_all_wallets(self) -> None:
+        """Delete every wallet in the repository."""
+        self.repo.delete_all_wallets()


### PR DESCRIPTION
## Summary
- allow deleting all wallets via new WalletCore method
- add injection helper for Star Wars wallets
- wire up new routes and UI buttons
- replace injection icon with a star and remove from wallets table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68424e24bbd883219fc279f4042c7256