### PR TITLE
Add wallet address to trader cards

### DIFF
--- a/static/css/trader_shop.css
+++ b/static/css/trader_shop.css
@@ -83,3 +83,9 @@
 #leaderboard-panel tfoot .leader-total-row {
   background-color: #e7f1ff;
 }
+
+.pub-address {
+  font-size: 0.75rem;
+  word-break: break-all;
+  margin-top: 0.5rem;
+}

--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -227,6 +227,7 @@ function loadTraders() {
               <p>Strategy Count: ${Object.keys(trader.strategies || {}).length}</p>
               <p>Born on: ${trader.born_on ? new Date(trader.born_on).toLocaleString() : 'N/A'}</p>
               <p>Initial Collateral: $${(trader.initial_collateral ?? 0).toFixed(2)}</p>
+              <p class="pub-address">${trader.public_address ?? 'N/A'}</p>
               <button class="btn btn-danger btn-sm mt-2" onclick="deleteTrader('${trader.name}')">Delete</button>
             </div>
           </div>

--- a/trader_core/trader_bp.py
+++ b/trader_core/trader_bp.py
@@ -23,6 +23,15 @@ def _enrich_trader(trader: dict, dl, pm: PersonaManager, calc: CalcServices) -> 
         (persona.name + "Vault") if persona else f"{name}Vault"
     )
 
+    wallet_info = None
+    if hasattr(dl, "get_wallet_by_name"):
+        try:
+            wallet_info = dl.get_wallet_by_name(wallet_name)
+        except Exception as exc:
+            log.debug(f"Wallet lookup failed: {exc}", source="TraderBP")
+    if wallet_info:
+        trader["public_address"] = wallet_info.get("public_address", "")
+
     positions = []
     if hasattr(dl, "positions"):
         pos_mgr = dl.positions


### PR DESCRIPTION
## Summary
- show wallet public address on each trader card
- style address text in trader shop
- include public address in trader API enrichment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', AttributeError: <class 'object'> has no attribute '_seed_modifiers_if_empty', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68425202d5908321bce42f4ce77a850c