### PR TITLE
Fix wallet creation with pydantic models

### DIFF
--- a/wallets/wallet_repository.py
+++ b/wallets/wallet_repository.py
@@ -39,9 +39,11 @@ class WalletRepository:
 
     # ➕ Insert new wallet into DB
     def add_wallet(self, wallet: WalletIn) -> None:
-        from dataclasses import asdict
+        """Persist ``wallet`` to the database."""
 
-        self.dl.create_wallet(asdict(wallet))
+        # ``WalletIn`` is a Pydantic model (or stub fallback) so we rely on
+        # its ``dict()`` method rather than ``dataclasses.asdict``.
+        self.dl.create_wallet(wallet.dict())
 
     # 🗑️ Delete wallet by name
     def delete_wallet(self, name: str) -> bool:


### PR DESCRIPTION
## Summary
- fix WalletRepository.add_wallet to use `wallet.dict()` instead of `dataclasses.asdict`

## Testing
- `pytest -q tests/test_wallets.py`
- `pytest -q` *(fails: missing dependencies/environment)*

------
https://chatgpt.com/codex/tasks/task_e_6842584f23b083218063128a54b7b2b8