### PR TITLE
Add wallet icons to positions table

### DIFF
--- a/app/positions_bp.py
+++ b/app/positions_bp.py
@@ -12,6 +12,7 @@ from core.logging import log
 from positions.position_core import PositionCore
 from calc_core.calculation_core import CalculationCore
 from calc_core.calc_services import CalcServices
+from dashboard.dashboard_service import WALLET_IMAGE_MAP, DEFAULT_WALLET_IMAGE
 from utils.route_decorators import route_log_alert
 
 
@@ -62,6 +63,8 @@ def list_positions():
             heat = float(pos.get("heat_index") or 0.0)
             pos["liqdist_alert_class"] = get_alert_class(liqd, liqd_cfg.get("low"), liqd_cfg.get("medium"), liqd_cfg.get("high"))
             pos["heat_alert_class"] = get_alert_class(heat, hi_cfg.get("low"), hi_cfg.get("medium"), hi_cfg.get("high"))
+            wallet_name = pos.get("wallet") or pos.get("wallet_name") or "Unknown"
+            pos["wallet_image"] = WALLET_IMAGE_MAP.get(wallet_name, DEFAULT_WALLET_IMAGE)
 
         totals = CalcServices().calculate_totals(positions)
         wallets = current_app.data_locker.read_wallets()
@@ -89,6 +92,9 @@ def positions_table():
     try:
         core = PositionCore(current_app.data_locker)
         positions = core.get_active_positions()
+        for pos in positions:
+            wallet_name = pos.get("wallet") or pos.get("wallet_name") or "Unknown"
+            pos["wallet_image"] = WALLET_IMAGE_MAP.get(wallet_name, DEFAULT_WALLET_IMAGE)
         totals = CalcServices().calculate_totals(positions)
         wallets = current_app.data_locker.read_wallets()
         return render_template(

--- a/templates/positions_table.html
+++ b/templates/positions_table.html
@@ -28,6 +28,21 @@
             {% else %}
               {{ pos.asset_type }}
             {% endif %}
+            {% set wallet_img = pos.wallet_image %}
+            {% if not wallet_img %}
+              {% set wallet_matches = wallets | selectattr('name', 'equalto', pos.wallet or pos.wallet_name) | list %}
+              {% set wallet = wallet_matches[0] if wallet_matches else None %}
+              {% if wallet and wallet.image_path %}
+                {% set wallet_img = wallet.image_path.lstrip('/') %}
+              {% else %}
+                {% set wallet_img = 'images/unknown_wallet.jpg' %}
+              {% endif %}
+            {% endif %}
+            {% if wallet_img.startswith('http') or wallet_img.startswith('/static/') %}
+              <img src="{{ wallet_img }}" alt="wallet" class="wallet-icon ms-1">
+            {% else %}
+              <img src="{{ url_for('static', filename=wallet_img if wallet_img.startswith('images/') else 'images/' + wallet_img) }}" alt="wallet" class="wallet-icon ms-1">
+            {% endif %}
           </td>
           <td class="right">{{ "{:,.0f}".format(pos.pnl_after_fees_usd or 0) }}</td>
           <td class="right">{{ "{:,.0f}".format(pos.collateral or 0) }}</td>
@@ -116,6 +131,15 @@
   display: inline-block;
   vertical-align: middle;
   margin-right: 7px;
+}
+.wallet-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 4px;
 }
 
 .sort-indicator {


### PR DESCRIPTION
## Summary
- add wallet image mapping when generating positions for the UI
- show wallet icon beside each asset in the positions table
- style wallet icons so they match asset icons

## Testing
- `pytest -q` *(fails: TypeError and other DB-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842b6d6be9c83219d6f1f195dffbb5b