### PR TITLE
Add bulk Star Wars trader creation and delete

### DIFF
--- a/data/dl_traders.py
+++ b/data/dl_traders.py
@@ -164,3 +164,14 @@ class DLTraderManager:
         except Exception as e:
             log.error(f"❌ Failed to delete trader '{name}': {e}", source="DLTraderManager")
             raise
+
+    def delete_all_traders(self):
+        """Remove all trader records from the database."""
+        try:
+            cursor = self.db.get_cursor()
+            cursor.execute("DELETE FROM traders")
+            self.db.commit()
+            log.success("🧹 All traders deleted", source="DLTraderManager")
+        except Exception as e:
+            log.error(f"❌ Failed to delete all traders: {e}", source="DLTraderManager")
+

--- a/static/css/trader_shop.css
+++ b/static/css/trader_shop.css
@@ -89,3 +89,25 @@
   word-break: break-all;
   margin-top: 0.5rem;
 }
+
+.yoda-btn {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  background-color: #198754;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+}
+
+.yoda-btn img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+}

--- a/static/js/trader_shop.js
+++ b/static/js/trader_shop.js
@@ -313,8 +313,46 @@ function deleteTrader(name) {
   });
 }
 
+function createStarWarsTraders() {
+  if (!confirm("Create Star Wars traders?")) return;
+  fetch('/trader/api/traders/create_star_wars', { method: 'POST' })
+    .then(res => res.json())
+    .then(data => {
+      if (data.success) {
+        alert('✅ Star Wars traders created!');
+        location.reload();
+      } else {
+        alert('❌ Failed to create traders.');
+      }
+    })
+    .catch(err => {
+      console.error('create star wars traders failed', err);
+      alert('❌ Error creating traders.');
+    });
+}
+
+function deleteAllTraders() {
+  if (!confirm('Delete ALL traders?')) return;
+  fetch('/trader/api/traders/delete_all', { method: 'POST' })
+    .then(res => res.json())
+    .then(data => {
+      if (data.success) {
+        alert('🧹 All traders deleted.');
+        location.reload();
+      } else {
+        alert('❌ Failed to delete traders.');
+      }
+    })
+    .catch(err => {
+      console.error('delete all traders failed', err);
+      alert('❌ Error deleting traders.');
+    });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   loadAvatars();
   loadWallets();
   loadTraders();
+  document.getElementById('starWarsBtn')?.addEventListener('click', createStarWarsTraders);
+  document.getElementById('deleteAllTradersBtn')?.addEventListener('click', deleteAllTraders);
 });

--- a/templates/trader_shop.html
+++ b/templates/trader_shop.html
@@ -20,9 +20,12 @@
       <div class="panel p-3 border rounded shadow-sm bg-light-subtle" id="traders-panel">
         <div class="d-flex justify-content-between align-items-center mb-3">
           <h2>👤 Traders</h2>
-          <button id="toggleTraderViewBtn" class="btn btn-outline-primary btn-sm" onclick="toggleTraderView()">
-            <i class="fas fa-plus"></i> <span id="toggleLabel">New Trader</span>
-          </button>
+          <div class="d-flex gap-2">
+            <button id="deleteAllTradersBtn" class="btn btn-danger btn-sm">Delete All</button>
+            <button id="toggleTraderViewBtn" class="btn btn-outline-primary btn-sm" onclick="toggleTraderView()">
+              <i class="fas fa-plus"></i> <span id="toggleLabel">New Trader</span>
+            </button>
+          </div>
         </div>
 
         <div id="trader-cards" class="d-flex flex-wrap gap-3">
@@ -72,6 +75,9 @@
               <button type="button" class="btn btn-secondary btn-sm" onclick="cancelCreate()">Cancel</button>
             </div>
           </form>
+          <button id="starWarsBtn" type="button" class="yoda-btn">
+            <img src="{{ url_for('static', filename='images/yoda_icon.jpg') }}" class="img-fluid" alt="Yoda">
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow seeding Star Wars traders with a single API call
- support deleting all traders at once
- show Delete All button and Yoda floating button in Trader Shop
- wire up JS handlers for the new buttons
- style the Yoda button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842d8e829408321b52ff0e0d196fd2c