### PR TITLE
Update theme builder to include title bar

### DIFF
--- a/templates/system/theme_builder.html
+++ b/templates/system/theme_builder.html
@@ -1,9 +1,14 @@
+
 {% extends "base.html" %}
 
 {% block title %}Theme Builder{% endblock %}
 
 {% block extra_styles %}
 {{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 <style>
   .theme-builder-wrapper {
     margin-top: 2rem;
@@ -91,6 +96,8 @@
 {% endblock %}
 
 {% block content %}
+{% set title_text = 'Theme Builder' %}
+{% include "title_bar.html" %}
 <div class="container theme-builder-wrapper">
   <h1>Theme Builder 🎨</h1>
 
@@ -160,5 +167,7 @@
 
 {% block extra_scripts %}
 {{ super() }}
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
 <script src="{{ url_for('static', filename='js/theme_builder.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend the theme builder page with styles for title_bar
- add title bar header to Theme Builder page
- load layout and theme scripts for consistency

## Testing
- `pytest -q` *(fails: 68 failed, 105 passed, 7 skipped, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842dc6086108321b8356badbf47a93f