### PR TITLE
Shrink dashboard top panels

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -32,12 +32,12 @@
   position: relative;
 }
 
-/* Portfolio and monitor panels with 25% less vertical padding */
+/* Portfolio and monitor panels with 20% less vertical padding */
 .portfolio-panel,
 .monitor-panel {
-  /* tweak these values to adjust panel height */
-  padding-top: 0.6rem;
-  padding-bottom: 1.8rem;
+  /* further reduced vertical padding for a more compact first row */
+  padding-top: 0.48rem;   /* 20% less than previous */
+  padding-bottom: 1.44rem; /* 20% less than previous */
 }
 
 /* Chart containers should span the full width of the panel */


### PR DESCRIPTION
## Summary
- tweak portfolio and monitor panel padding to make the first dashboard row shorter

## Testing
- `pytest -q` *(fails: 68 failed, 105 passed, 7 skipped, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842dcb361948321a21a4b54e048b5e0