### PR TITLE
Remove Delete All button from trader panel

### DIFF
--- a/templates/trader_shop.html
+++ b/templates/trader_shop.html
@@ -21,7 +21,6 @@
         <div class="d-flex justify-content-between align-items-center mb-3">
           <h2>👤 Traders</h2>
           <div class="d-flex gap-2">
-            <button id="deleteAllTradersBtn" class="btn btn-danger btn-sm">Delete All</button>
             <button id="toggleTraderViewBtn" class="btn btn-outline-primary btn-sm" onclick="toggleTraderView()">
               <i class="fas fa-plus"></i> <span id="toggleLabel">New Trader</span>
             </button>


### PR DESCRIPTION
## Summary
- remove the Delete All button from the top-level trader panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684334a6bb508321bb30f203ce3417b8